### PR TITLE
chore: work on managing releases and service info

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,23 @@
+# configure github generated release notes
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
+# uses labels that can be affected implicitly based on PR titles, see workflow/conventional-label.yaml
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking
+    - title: New Features 🎉
+      labels:
+        - feature
+    - title: Fixes 🔧
+      labels:
+        - fix
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/conventional-label.yaml
+++ b/.github/workflows/conventional-label.yaml
@@ -1,0 +1,12 @@
+# automatic labelling of pull request based on conventional commit names in the PR titles
+# see https://github.com/marketplace/actions/conventional-release-labels
+
+on:
+  pull_request_target:
+    types: [ opened, edited ]
+name: conventional-release-labels
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bcoe/conventional-release-labels@v1

--- a/server/app.js
+++ b/server/app.js
@@ -47,6 +47,7 @@ app.use(bodyParser.text())
 app.use(session.auth)
 app.set('session', session)
 app.use('/api/v1', require('./router/root'))
+app.use('/api/v1/admin', require('./router/admin'))
 app.use('/api/v1/portals', require('./router/portals'))
 
 app.use('/api/', (req, res) => {

--- a/server/router/admin.js
+++ b/server/router/admin.js
@@ -1,0 +1,22 @@
+const express = require('express')
+const status = require('../utils/status')
+const asyncWrap = require('../utils/async-wrap')
+
+const router = module.exports = express.Router()
+
+// All routes in the router are only for the super admins of the service
+router.use(asyncWrap(async (req, res, next) => {
+  if (!req.user) return res.status(401).type('text/plain').send()
+  if (!req.user.adminMode) return res.status(403).type('text/plain').send()
+  next()
+}))
+
+let info = { version: process.env.NODE_ENV }
+try { info = require('../../BUILD.json') } catch (err) {}
+router.get('/info', (req, res) => {
+  res.send(info)
+})
+
+router.get('/status', (req, res, next) => {
+  status.status(req, res, next)
+})

--- a/server/router/root.js
+++ b/server/router/root.js
@@ -4,14 +4,6 @@ const status = require('../utils/status')
 
 const router = express.Router()
 
-let info = { version: process.env.NODE_ENV }
-try { info = require('../../BUILD.json') } catch (err) {}
-router.get('/info', (req, res) => {
-  if (!req.user) return res.status(401).send()
-  res.send(info)
-})
-
-router.get('/status', status.status)
 router.get('/ping', status.ping)
 
 module.exports = router

--- a/test/root.js
+++ b/test/root.js
@@ -2,21 +2,21 @@ const assert = require('assert').strict
 
 describe('root', () => {
   it('Get service info', async () => {
-    const ax = global.ax.user1
-    const res = await ax.get('/api/v1/info')
+    const ax = global.ax.superadmin
+    const res = await ax.get('/api/v1/admin/info')
     assert.equal(res.status, 200)
     assert.equal(res.data.version, 'test')
   })
 
   it('Get service status', async () => {
     const ax = global.ax.superadmin
-    const res = await ax.get('/api/v1/status')
+    const res = await ax.get('/api/v1/admin/status')
     assert.equal(res.status, 200)
     assert.equal(res.data.status, 'ok')
   })
 
   it('Ping service status', async () => {
-    const ax = global.ax.superadmin
+    const ax = global.ax.anonymous
     const res = await ax.get('/api/v1/ping')
     assert.equal(res.status, 200)
     assert.equal(res.data, 'ok')


### PR DESCRIPTION
Uses conventional pull request titles and labels to manage Github generated release notes.

Also expose /api/v1/admin/infos to be used to display version badges in data-fair.