### PR TITLE
feat: send better analytics

### DIFF
--- a/api/types/portal-config-links/schema.js
+++ b/api/types/portal-config-links/schema.js
@@ -40,7 +40,7 @@ export default {
             { const: 'terms-of-service', title: 'Conditions générales d\'utilisation' },
             { const: 'datasets', title: 'Catalogue de données' },
             { const: 'applications', title: 'Catalogue de visualisations' },
-            { const: 'reuses', title: 'Liste des réutilisations' },
+            { const: 'reuses', title: 'Catalogue de réutilisations' },
             { const: 'event', title: 'Liste des événements' },
             { const: 'news', title: 'Liste des actualités' },
             { const: 'sitemap', title: 'Plan du site' }
@@ -184,7 +184,7 @@ const linkItemTitleFn = (item) => {
     'terms-of-service': 'Conditions générales d\'utilisation',
     datasets: 'Catalogue de données',
     applications: 'Catalogue de visualisations',
-    reuses: 'Liste des réutilisations',
+    reuses: 'Catalogue de réutilisations',
     event: 'Liste des événements',
     news: 'Liste des actualités',
     sitemap: 'Plan du site'

--- a/portal/app/components/action-btn.vue
+++ b/portal/app/components/action-btn.vue
@@ -12,7 +12,7 @@
     :density="actionStyle === 'icon' ? 'comfortable' : undefined"
     :size="actionStyle !== 'icon' ? 'small' : undefined"
     :block="block"
-    class="justify-start"
+    :class="{ 'justify-start': actionStyle !== 'icon' }"
     variant="text"
   />
 </template>

--- a/portal/app/components/application/application-embed.vue
+++ b/portal/app/components/application/application-embed.vue
@@ -6,7 +6,7 @@
     :resource-title="application.title"
     :text="t('embed')"
     :short-text="t('embedShort')"
-    :track-path="`/applications/${application.slug}/embed-dialog`"
+    :track-dialog="{ action: 'application-embed', label: application.slug }"
   >
     <v-card-text class="py-0">
       {{ t('description') }}

--- a/portal/app/components/application/application-preview.vue
+++ b/portal/app/components/application/application-preview.vue
@@ -6,7 +6,7 @@
     :resource-title="application.title"
     :text="t('preview')"
     :short-text="t('previewShort')"
-    :track-path="`/applications/${application.slug}/preview-dialog`"
+    :track-dialog="{ action: 'application-preview', label: application.slug }"
     :block="block"
   >
     <d-frame-wrapper

--- a/portal/app/components/dataset/dataset-attachments-preview.vue
+++ b/portal/app/components/dataset/dataset-attachments-preview.vue
@@ -5,7 +5,7 @@
     :icon="mdiAttachment"
     :resource-title="dataset.title"
     :text="t('preview')"
-    :track-path="`/datasets/${dataset.slug}/attachments-dialog`"
+    :track-dialog="{ action: 'dataset-attachments', label: dataset.slug }"
   >
     <dataset-attachments :dataset="dataset" />
   </layout-preview>

--- a/portal/app/components/dataset/dataset-embed.vue
+++ b/portal/app/components/dataset/dataset-embed.vue
@@ -6,7 +6,7 @@
     :resource-title="dataset.title"
     :text="t('embed')"
     :short-text="t('embedShort')"
-    :track-path="`/datasets/${dataset.slug}/embed-dialog`"
+    :track-dialog="{ action: 'dataset-embed', label: dataset.slug }"
   >
     <v-card-text class="py-0">
       <v-row>

--- a/portal/app/components/dataset/dataset-notifications.vue
+++ b/portal/app/components/dataset/dataset-notifications.vue
@@ -5,7 +5,7 @@
     :icon="mdiBell"
     :resource-title="dataset.title"
     :text="t('preview')"
-    :track-path="`/datasets/${dataset.slug}/notifications-dialog`"
+    :track-dialog="{ action: 'dataset-notifications', label: dataset.slug }"
   >
     <d-frame-wrapper
       :iframe-title="t('preview') + ' - ' + dataset.title"

--- a/portal/app/components/dataset/dataset-schema.vue
+++ b/portal/app/components/dataset/dataset-schema.vue
@@ -6,7 +6,7 @@
     :resource-title="dataset.title"
     :text="t('preview')"
     :short-text="t('previewShort')"
-    :track-path="`/datasets/${dataset.slug}/notifications-dialog`"
+    :track-dialog="{ action: 'dataset-schema', label: dataset.slug }"
   >
     <d-frame-wrapper
       :iframe-title="t('preview') + ' - ' + dataset.title"

--- a/portal/app/components/layout/layout-preview.vue
+++ b/portal/app/components/layout/layout-preview.vue
@@ -40,7 +40,7 @@
 import type { DatasetCard } from '#api/types/portal/index.js'
 import { mdiClose } from '@mdi/js'
 
-const { trackPath } = defineProps<{
+const { trackDialog } = defineProps<{
   /** Dialog title */
   title?: string
   /** Button action style */
@@ -53,17 +53,17 @@ const { trackPath } = defineProps<{
   text: string
   /** Button short text */
   shortText?: string
-  /** Used to track a page view when this dialog is opened */
-  trackPath?: string
+  /** Used to track a dialog open event */
+  trackDialog?: { action: string, label: string }
   /** Whether the button should take the full width of its container */
   block?: boolean
 }>()
 
 const dialog = ref(false)
 
-if (trackPath) {
-  watch(dialog, () => {
-    useAnalytics()?.page({ title: trackPath })
+if (trackDialog) {
+  watch(dialog, (opened) => {
+    if (opened) useAnalytics()?.track(trackDialog.action, { category: 'dialog', label: trackDialog.label })
   })
 }
 </script>

--- a/portal/app/components/page-element/applications/page-element-applications-catalog.vue
+++ b/portal/app/components/page-element/applications/page-element-applications-catalog.vue
@@ -214,15 +214,6 @@ if (!preview) {
   applicationsFetch = useLocalFetch<ApplicationFetch>('/data-fair/api/v1/applications', { query: applicationsQuery, watch: false })
 }
 
-// TODO: Track applications search ?
-// Track searches
-// if (!preview) {
-//   // TODO: ask if params are tracked, in this case, this track is useless
-//   watch(filters.search, () => {
-//     if (filters.search.value) useAnalytics()?.track('search', { category: 'datasets', label: filters.search.value })
-//   })
-// }
-
 // Computed property to check if there are more datasets to load (for infinite scroll)
 const hasMore = computed(() => {
   if (preview || paginationPosition.value !== 'none') return false
@@ -304,7 +295,10 @@ if (!preview) {
     if (applicationsFetch?.data.value?.results) {
       displayedApplications.value = [...applicationsFetch.data.value.results]
     }
-    // goTo(catalogTop.value)
+    // Track search event with analytics
+    if (filters.search.value) {
+      useAnalytics()?.track('search', { category: 'applications', label: filters.search.value, resultsCount: applicationsFetch?.data.value?.count ?? 0 })
+    }
   })
 }
 

--- a/portal/app/components/page-element/basic/page-element-search.vue
+++ b/portal/app/components/page-element/basic/page-element-search.vue
@@ -60,13 +60,27 @@ const { element } = defineProps<{
 
 const { t } = useI18n()
 const router = useRouter()
+const route = useRoute()
 const { preview } = usePortalStore()
 const search = useStringSearchParam('q')
 
 const searchQuery = ref(search.value || '')
 
+const searchCategory = computed(() => {
+  if (route.path.startsWith('/datasets')) return 'datasets'
+  if (route.path.startsWith('/applications')) return 'applications'
+  if (route.path.startsWith('/reuses')) return 'reuses'
+  if (element.redirectPage) return 'datasets'
+  return undefined
+})
+
 const onSearch = () => {
   if (!preview) {
+    if (searchQuery.value) {
+      const properties: Record<string, string> = { label: searchQuery.value }
+      if (searchCategory.value) properties.category = searchCategory.value
+      useAnalytics()?.track('search', properties)
+    }
     if (element.redirectPage) {
       router.push({
         path: '/datasets',

--- a/portal/app/components/page-element/datasets/page-element-dataset-table.vue
+++ b/portal/app/components/page-element/datasets/page-element-dataset-table.vue
@@ -7,7 +7,7 @@
     scrolling="no"
     aspect-ratio
     emit-iframe-messages
-    @iframe-message="(iframeMessage: CustomEvent) => onIframeMessage(iframeMessage.detail)"
+    @iframe-message="(iframeMessage: CustomEvent) => onIframeTrackMessage(iframeMessage.detail)"
   />
 </template>
 
@@ -23,11 +23,6 @@ const url = computed(() => {
   if (element.cols && element.cols.length) ret += `&cols=${element.cols.join(',')}`
   return ret
 })
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const onIframeMessage = (message: any) => {
-  if (message) useAnalytics()?.track(message.trackEvent.action, message.trackEvent)
-}
 
 </script>
 

--- a/portal/app/components/page-element/datasets/page-element-datasets-catalog.vue
+++ b/portal/app/components/page-element/datasets/page-element-datasets-catalog.vue
@@ -238,14 +238,6 @@ if (!preview) {
   datasetsFetch = useLocalFetch<DatasetFetch>('/data-fair/api/v1/datasets', { query: datasetsQuery, watch: false })
 }
 
-// Track searches
-if (!preview) {
-  // TODO: ask if params are tracked, in this case, this track is useless
-  watch(filters.search, () => {
-    if (filters.search.value) useAnalytics()?.track('search', { category: 'datasets', label: filters.search.value })
-  })
-}
-
 // Computed property to check if there are more datasets to load (for infinite scroll)
 const hasMore = computed(() => {
   if (preview || paginationPosition.value !== 'none') return false
@@ -323,7 +315,10 @@ if (!preview) {
     if (datasetsFetch?.data.value?.results) {
       displayedDatasets.value = [...datasetsFetch.data.value.results]
     }
-    // goTo(catalogTop.value)
+    // Track search event with analytics
+    if (filters.search.value) {
+      useAnalytics()?.track('search', { category: 'datasets', label: filters.search.value, resultsCount: datasetsFetch?.data.value?.count ?? 0 })
+    }
   })
 }
 

--- a/portal/app/components/page-element/reuses/page-element-reuses-catalog.vue
+++ b/portal/app/components/page-element/reuses/page-element-reuses-catalog.vue
@@ -206,13 +206,6 @@ if (!preview) {
   reusesFetch = useFetch<ReuseFetch>('/portal/api/reuses', { query: reusesQuery, watch: false })
 }
 
-// Track searches
-if (!preview) {
-  watch(filters.search, () => {
-    if (filters.search.value) useAnalytics()?.track('search', { category: 'reuses', label: filters.search.value })
-  })
-}
-
 // Computed property to check if there are more reuses to load (for infinite scroll)
 const hasMore = computed(() => {
   if (preview || paginationPosition.value !== 'none') return false
@@ -287,6 +280,10 @@ if (!preview) {
     await reusesFetch?.refresh()
     if (reusesFetch?.data.value?.results) {
       displayedReuses.value = [...reusesFetch.data.value.results]
+    }
+    // Track search event with analytics
+    if (filters.search.value) {
+      useAnalytics()?.track('search', { category: 'reuses', label: filters.search.value, resultsCount: reusesFetch?.data.value?.count ?? 0 })
     }
   })
 }

--- a/portal/app/components/reuse/reuse-preview.vue
+++ b/portal/app/components/reuse/reuse-preview.vue
@@ -142,12 +142,12 @@ const datasets = computed(() => datasetsFetch.data.value?.results || [])
 
 <i18n lang="yaml">
   en:
-    backToReuses: Back to Reuses List
+    backToReuses: Go to reuses catalog
     visitLink: View reuse
     publishedBy: Published by {author}
     datasetsUsed: Dataset used | Datasets used
   fr:
-    backToReuses: Retourner à la liste des réutilisations
+    backToReuses: Aller au catalogue de réutilisations
     visitLink: Voir la réutilisation
     publishedBy: Publié par {author}
     datasetsUsed: Jeu de données utilisé | Jeux de données utilisés

--- a/portal/app/composables/use-analytics.ts
+++ b/portal/app/composables/use-analytics.ts
@@ -5,6 +5,17 @@ const _window = window as any
 
 export const useAnalytics = () => _window.__ANALYTICS as AnalyticsInstance | undefined
 
+interface IframeTrackMessage { trackEvent: { action: string, label: string } }
+const isIframeTrackMessage = (message: unknown): message is IframeTrackMessage => {
+  return typeof message === 'object' &&
+    message !== null &&
+    'trackEvent' in message &&
+    typeof (message as IframeTrackMessage).trackEvent?.action === 'string'
+}
+export const onIframeTrackMessage = (message: unknown) => {
+  if (isIframeTrackMessage(message)) useAnalytics()?.track(message.trackEvent.action, message.trackEvent)
+}
+
 export const useAnalyticsInfo = (portal: RequestPortal) => {
   const cookieTrack = useCookie<'yes' | 'no' | undefined>('df_portal_track', { maxAge: 60 * 60 * 24 * 365, sameSite: true, path: '/' })
   const cookieTrackOptOut = useCookie('df_portal_track_opt_out', { maxAge: 60 * 60 * 24 * 365, sameSite: true, path: '/' })

--- a/portal/app/pages/datasets/[ref]/table.vue
+++ b/portal/app/pages/datasets/[ref]/table.vue
@@ -7,7 +7,7 @@
     scrolling="no"
     sync-params
     emit-iframe-messages
-    @iframe-message="(iframeMessage: CustomEvent) => onIframeMessage(iframeMessage.detail)"
+    @iframe-message="(iframeMessage: CustomEvent) => onIframeTrackMessage(iframeMessage.detail)"
   />
 </template>
 
@@ -52,11 +52,6 @@ const thumbnailUrl = computed(() => {
   if (cardConfig.thumbnail?.default) return getPortalImageSrc(cardConfig.thumbnail.default, false)
   return undefined
 })
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const onIframeMessage = (message: any) => {
-  if (message) useAnalytics()?.track(message.trackEvent.action, message.trackEvent)
-}
 
 watch(datasetFetch.data, () => {
   setBreadcrumbs([

--- a/portal/app/utils/analytics/matomo.ts
+++ b/portal/app/utils/analytics/matomo.ts
@@ -41,7 +41,15 @@ export default function matomoPlugin (params: MatomoPluginConfig): AnalyticsPlug
     },
     track: ({ payload }) => {
       debug('track', payload)
-      _window._paq.push(['trackEvent', payload.properties.category, payload.event, payload.properties.label])
+      if (payload.event === 'search') {
+        // https://developer.matomo.org/guides/tracking-javascript-guide#internal-search-tracking
+        _window._paq.push(['trackSiteSearch', payload.properties.label, payload.properties.category, payload.properties.resultsCount])
+      } else if (payload.event.startsWith('download')) {
+        const url = payload.properties.url || `${window.location.origin}/download/${payload.properties.label}`
+        _window._paq.push(['trackLink', url, 'download'])
+      } else {
+        _window._paq.push(['trackEvent', payload.properties.category, payload.event, payload.properties.label])
+      }
     }
   }
 

--- a/portal/app/utils/analytics/piano.ts
+++ b/portal/app/utils/analytics/piano.ts
@@ -25,11 +25,15 @@ export default function pianoPlugin (params: PianoPluginConfig): AnalyticsPlugin
     },
     track: ({ payload }) => {
       debug('track', payload)
-      pianoAnalytics.sendEvent('page.display', { page: payload.properties.title })
       if (payload.event === 'search') {
-        pianoAnalytics.sendEvent('internal_search_result.display', { ise_keyword: payload.properties.label })
+        pianoAnalytics.sendEvent('internal_search_result.display', {
+          ise_keyword: payload.properties.label,
+          ise_page: 1,
+          ...(payload.properties.resultsCount !== undefined && { ise_count: payload.properties.resultsCount })
+        })
       } else if (payload.event.startsWith('download')) {
-        pianoAnalytics.sendEvent('click.download', { click: payload.event, click_chapter1: payload.properties.label })
+        const url = payload.properties.url || `${window.location.origin}/download/${payload.properties.label}`
+        pianoAnalytics.sendEvent('click.download', { click: payload.event, click_chapter1: payload.properties.label, src_url: url })
       } else {
         pianoAnalytics.sendEvent('click.action', { click: payload.event, click_chapter1: payload.properties.label })
       }

--- a/ui/src/composables/nuxt-composables.ts
+++ b/ui/src/composables/nuxt-composables.ts
@@ -27,6 +27,10 @@ export function useAnalyticsInfo (_portal: any): any {
   throw new Error('useAnalytics should only be called from portal, not portals-manager')
 }
 
+export function onIframeTrackMessage (_message: unknown): void {
+  throw new Error('onIframeTrackMessage should only be called from portal, not portals-manager')
+}
+
 export function useRequestEvent (): any {
   throw new Error('useRequestEvent should only be called from portal, not portals-manager')
 }


### PR DESCRIPTION
Improve analytics tracking consistency and event quality across the portal.

* Improve download event tracking: include download URL and category, and fix URL to use dataset slug.
* Improve search event tracking: include search term, category, and result count. Events are now sent after results are fetched instead of on input change.
* Standardize dialog tracking using a structured event format (action + label).
* Improve iframe analytics handling with a shared tracking helper.
* Update Matomo integration to use dedicated APIs for search and download events.
* Minor UI and wording adjustments for consistency (French labels, button alignment).