### PR TITLE
feat: add global configuration for elevation, density, and rounded properties

### DIFF
--- a/api/types/common-application-card/schema.js
+++ b/api/types/common-application-card/schema.js
@@ -170,21 +170,11 @@ export default {
           title: 'Afficher les thématiques',
           layout: 'switch',
         },
-        color: {
-          $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/color-topics'
-        },
-        elevation: {
-          $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/elevation'
-        },
-        density: {
-          $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/density'
-        },
-        rounded: {
-          $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/rounded'
-        },
-        variant: {
-          $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/variant'
-        },
+        color: { $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/color-topics' },
+        elevation: { $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/elevation' },
+        density: { $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/density' },
+        rounded: { $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/rounded' },
+        variant: { $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/variant' },
         showIcon: {
           type: 'boolean',
           title: "Afficher l'icône",

--- a/api/types/common-dataset-card/schema.js
+++ b/api/types/common-dataset-card/schema.js
@@ -103,7 +103,7 @@ export default {
               { key: 'crop', cols: { md: 4 } },
               { key: 'useTopic', cols: { md: 4 } },
               { key: 'useApplication', cols: { md: 4 } },
-              { markdown: "**Ordre de priorité :**\n1. **Image spécifique** (définie directement sur le jeu de données)\n2. **Image de la thématique** (si activé)\n3. **Image de l'application** (si activé)\n4. **Image par défaut** (si définie)" }
+              { markdown: '**Ordre de priorité :**\n1. **Image spécifique** (définie directement sur le jeu de données)\n2. **Image de la thématique** (si activé)\n3. **Image de la visualisation** (si activé)\n4. **Image par défaut** (si définie)' }
             ]
           },
         ]
@@ -169,8 +169,8 @@ export default {
         },
         useApplication: {
           type: 'boolean',
-          title: "Utiliser l'image de la première application",
-          description: "Permet d'utiliser l'image de la première application qui utilise ce jeu de données si aucune image n'est définie pour ce dernier.",
+          title: "Utiliser l'image de la première visualisation",
+          description: "Permet d'utiliser l'image de la première visualisation qui utilise ce jeu de données si aucune image n'est définie pour ce dernier.",
           layout: 'switch',
           default: false
         }

--- a/api/types/common-defs/schema.js
+++ b/api/types/common-defs/schema.js
@@ -218,8 +218,7 @@ export default {
         },
         elevation: {
           $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/elevation',
-          layout: { cols: { md: 4 } },
-          default: 1
+          layout: { cols: { md: 4 } }
         },
         density: {
           $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/density',

--- a/api/types/page-element-layout/schema.js
+++ b/api/types/page-element-layout/schema.js
@@ -632,7 +632,7 @@ export default {
         // },
         // notStatic: {
         //   title: 'Agrandissement des titres',
-        //   description: 'Si activé, les titres des panneaux actifs s’agrandissent.'
+        //   description: 'Si activé, les titres des panneaux actifs s'agrandissent.'
         //   type: 'boolean',
         //   default: false
         // },

--- a/api/types/page-element-reuses/schema.js
+++ b/api/types/page-element-reuses/schema.js
@@ -85,12 +85,8 @@ export default {
                 ]
               }
             },
-            density: {
-              $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/density'
-            },
-            rounded: {
-              $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/rounded'
-            }
+            density: { $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/density' },
+            rounded: { $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/rounded' }
           }
         },
         pagination: {

--- a/api/types/portal-config-applications/schema.js
+++ b/api/types/portal-config-applications/schema.js
@@ -8,7 +8,7 @@ export default {
       {
         title: 'Application Card',
         'x-i18n-title': {
-          fr: "Vignette d'une application"
+          fr: "Vignette d'une visualisation"
         },
         children: [
           'card',

--- a/api/types/portal-config-labels-overrides/schema.js
+++ b/api/types/portal-config-labels-overrides/schema.js
@@ -7,7 +7,7 @@ export default {
     owner: {
       type: 'string',
       title: 'Propriétaire',
-      description: 'Surcharge le terme `propriétaire`, utilisé dans les métadonnées des jeux de données et des applications ainsi que dans les filtres associés.',
+      description: 'Surcharge le terme `propriétaire`, utilisé dans les métadonnées des jeux de données et des visualisations ainsi que dans les filtres associés.',
     }
   }
 }

--- a/api/types/portal-config-social-shares/schema.js
+++ b/api/types/portal-config-social-shares/schema.js
@@ -6,7 +6,7 @@ export default {
     fr: 'Réseaux sociaux proposés pour le partage'
   },
   type: 'array',
-  description: 'Ces réseaux sociaux seront proposés aux utilisateurs pour le partage de jeux de données et applications qui sont publiques.',
+  description: 'Ces réseaux sociaux seront proposés aux utilisateurs pour le partage de jeux de données et de visualisations qui sont publiques.',
   items: {
     type: 'string',
     oneOf: [

--- a/api/types/portal-config/schema.js
+++ b/api/types/portal-config/schema.js
@@ -77,7 +77,7 @@ export default {
           },
           {
             title: 'Style visuel par défaut',
-            subtitle: "Paramètres visuels globaux appliqués par défaut à l'ensemble du portail. Ces valeurs peuvent être surchargées dans chaque bloc ou composant spécifique pour adapter le style selon les besoins.",
+            subtitle: "Paramètres visuels globaux appliqués par défaut à l'ensemble du portail. Ces valeurs peuvent être surchargées dans chaque bloc ou composant spécifique pour adapter le style selon les besoins. Ces paramètres impactent toutes les vignettes, les boutons et menu de navigations, les thématiques et mots clés, les blocs, boite, onglets, accordéons, barre de recherche, formulaire de contact,... quand leurs paramètres d'élévation, de densité et d'arrondi ne sont pas définis.",
             comp: 'card',
             children: ['defaults']
           },

--- a/api/types/portal-config/schema.js
+++ b/api/types/portal-config/schema.js
@@ -76,6 +76,12 @@ export default {
             ]
           },
           {
+            title: 'Style visuel par défaut',
+            subtitle: "Paramètres visuels globaux appliqués par défaut à l'ensemble du portail. Ces valeurs peuvent être surchargées dans chaque bloc ou composant spécifique pour adapter le style selon les besoins.",
+            comp: 'card',
+            children: ['defaults']
+          },
+          {
             title: 'Rendu des liens de navigation',
             comp: 'card',
             children: [
@@ -406,7 +412,27 @@ export default {
     },
     personal: { $ref: 'https://github.com/data-fair/portals/portal-config-personal' },
     topics: { $ref: 'https://github.com/data-fair/portals/portal-config-topics' },
-    labelsOverrides: { $ref: 'https://github.com/data-fair/portals/portal-config-labels-overrides' }
+    labelsOverrides: { $ref: 'https://github.com/data-fair/portals/portal-config-labels-overrides' },
+    defaults: {
+      type: 'object',
+      properties: {
+        elevation: {
+          $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/elevation',
+          layout: { cols: { md: 4 } },
+          default: 1
+        },
+        density: {
+          $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/density',
+          layout: { cols: { md: 4 } },
+          default: 'comfortable'
+        },
+        rounded: {
+          $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/rounded',
+          layout: { cols: { md: 4 } },
+          default: 'default'
+        }
+      }
+    }
   },
   $defs: {
     menuItem: {

--- a/portal/app/components/application/application-metadata.vue
+++ b/portal/app/components/application/application-metadata.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card
-    :rounded="metadataConfig.rounded"
-    :elevation="metadataConfig.elevation"
+    :rounded="metadataConfig.rounded ?? portalConfig.defaults?.rounded"
+    :elevation="metadataConfig.elevation ?? portalConfig.defaults?.elevation"
   >
     <!-- Application Metadata -->
     <v-row class="ma-0">

--- a/portal/app/components/catalog-filters.vue
+++ b/portal/app/components/catalog-filters.vue
@@ -9,8 +9,8 @@
       v-model="search"
       :append-inner-icon="mdiMagnify"
       :label="t('search')"
-      :density="config.filters?.density || 'comfortable'"
-      :rounded="config.filters?.rounded"
+      :density="config.filters?.density ?? portalConfig.defaults?.density"
+      :rounded="config.filters?.rounded ?? portalConfig.defaults?.rounded"
       variant="outlined"
       autofocus
       clearable
@@ -32,8 +32,8 @@
       :items="conceptsItems"
       :label="t('filters.concepts')"
       :no-data-text="t('filters.noConcepts')"
-      :density="config.filters?.density || 'comfortable'"
-      :rounded="config.filters?.rounded"
+      :density="config.filters?.density ?? portalConfig.defaults?.density"
+      :rounded="config.filters?.rounded ?? portalConfig.defaults?.rounded"
       variant="outlined"
       chips
       clearable
@@ -54,8 +54,8 @@
       :items="baseApplicationItems"
       :label="t('filters.baseApplication')"
       :no-data-text="t('filters.noBaseApplication')"
-      :density="config.filters?.density || 'comfortable'"
-      :rounded="config.filters?.rounded"
+      :density="config.filters?.density ?? portalConfig.defaults?.density"
+      :rounded="config.filters?.rounded ?? portalConfig.defaults?.rounded"
       variant="outlined"
       chips
       clearable
@@ -78,8 +78,8 @@
       :items="facets.topics"
       :item-title="(item) => `${item.value.title} (${item.count})`"
       :item-value="(item) => item.value.id"
-      :density="config.filters?.density || 'comfortable'"
-      :rounded="config.filters?.rounded"
+      :density="config.filters?.density ?? portalConfig.defaults?.density"
+      :rounded="config.filters?.rounded ?? portalConfig.defaults?.rounded"
       variant="outlined"
       chips
       clearable
@@ -118,8 +118,8 @@
       :items="facets.keywords"
       :item-title="(item) => `${item.value} (${item.count})`"
       item-value="value"
-      :density="config.filters?.density || 'comfortable'"
-      :rounded="config.filters?.rounded"
+      :density="config.filters?.density ?? portalConfig.defaults?.density"
+      :rounded="config.filters?.rounded ?? portalConfig.defaults?.rounded"
       variant="outlined"
       chips
       clearable
@@ -140,8 +140,8 @@
       :label="portalConfig.labelsOverrides?.owner || t('filters.owners')"
       :no-data-text="t(`filters.${portalConfig.labelsOverrides?.owner ? 'noChoices' : 'noOwners'}`)"
       :items="ownersItems"
-      :density="config.filters?.density || 'comfortable'"
-      :rounded="config.filters?.rounded"
+      :density="config.filters?.density ?? portalConfig.defaults?.density"
+      :rounded="config.filters?.rounded ?? portalConfig.defaults?.rounded"
       variant="outlined"
       chips
       clearable
@@ -174,8 +174,8 @@
     <v-checkbox
       v-model="filters.includePast.value"
       :label="t('filters.includePastEvents')"
-      :density="config.filters?.density || 'comfortable'"
-      :rounded="config.filters?.rounded"
+      :density="config.filters?.density ?? portalConfig.defaults?.density"
+      :rounded="config.filters?.rounded ?? portalConfig.defaults?.rounded"
       color="primary"
       hide-details
     />
@@ -191,8 +191,8 @@
       v-model="sort"
       :items="sortItems"
       :label="t('sort.by')"
-      :density="config.filters?.density || 'comfortable'"
-      :rounded="config.filters?.rounded"
+      :density="config.filters?.density ?? portalConfig.defaults?.density"
+      :rounded="config.filters?.rounded ?? portalConfig.defaults?.rounded"
       variant="outlined"
       hide-details
       clearable
@@ -201,8 +201,8 @@
         <!-- Order toggle -->
         <v-btn-toggle
           v-model="order"
-          :density="config.filters?.density || 'comfortable'"
-          :rounded="config.filters?.rounded"
+          :density="config.filters?.density ?? portalConfig.defaults?.density"
+          :rounded="config.filters?.rounded ?? portalConfig.defaults?.rounded"
           variant="outlined"
           class="h-100"
           divided
@@ -232,8 +232,8 @@
   >
     <v-btn-toggle
       v-model="order"
-      :density="config.filters?.density || 'comfortable'"
-      :rounded="config.filters?.rounded"
+      :density="config.filters?.density ?? portalConfig.defaults?.density"
+      :rounded="config.filters?.rounded ?? portalConfig.defaults?.rounded"
       variant="outlined"
       class="w-100"
       divided

--- a/portal/app/components/dataset/dataset-card.vue
+++ b/portal/app/components/dataset/dataset-card.vue
@@ -5,8 +5,8 @@
   -->
   <v-card
     :to="!preview ? `/datasets/${dataset.slug}` : undefined"
-    :elevation="cardConfig.elevation ?? 0"
-    :rounded="cardConfig.rounded ?? 'default'"
+    :elevation="cardConfig.elevation ?? portalConfig.defaults?.elevation"
+    :rounded="cardConfig.rounded ?? portalConfig.defaults?.rounded"
     class="h-100 d-flex flex-column"
     link
   >

--- a/portal/app/components/dataset/dataset-metadata.vue
+++ b/portal/app/components/dataset/dataset-metadata.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card
-    :rounded="metadataConfig.rounded"
-    :elevation="metadataConfig.elevation"
+    :rounded="metadataConfig.rounded ?? portalConfig.defaults?.rounded"
+    :elevation="metadataConfig.elevation ?? portalConfig.defaults?.elevation"
   >
     <!-- Dataset Metadata -->
     <v-row class="ma-0">

--- a/portal/app/components/event/event-card.vue
+++ b/portal/app/components/event/event-card.vue
@@ -1,8 +1,8 @@
 <template>
   <v-card
     :to="!preview ? `/event/${pageConfig.eventMetadata?.slug}` : undefined"
-    :elevation="cardConfig.elevation ?? 0"
-    :rounded="cardConfig.rounded ?? 'default'"
+    :elevation="cardConfig.elevation ?? portalConfig.defaults?.elevation"
+    :rounded="cardConfig.rounded ?? portalConfig.defaults?.rounded"
     class="h-100 d-flex flex-column"
     link
   >
@@ -81,7 +81,7 @@ const { pageConfig, cardConfig, isPortalConfig } = defineProps<{
 }>()
 
 const { dayjs } = useLocaleDayjs()
-const { preview } = usePortalStore()
+const { portalConfig, preview } = usePortalStore()
 const getPageImageSrc = usePageImageSrc()
 const getPortalImageSrc = usePortalImageSrc()
 

--- a/portal/app/components/nav/nav-link.vue
+++ b/portal/app/components/nav/nav-link.vue
@@ -8,9 +8,9 @@
     :target="link.target ? '_blank' : undefined"
     :rel="link.target ? 'noopener' : undefined"
     :color="config?.color"
-    :density="config?.density"
-    :elevation="config?.elevation"
-    :rounded="config?.rounded"
+    :density="config?.density ?? portalConfig.defaults?.density"
+    :elevation="config?.elevation ?? portalConfig.defaults?.elevation"
+    :rounded="config?.rounded ?? portalConfig.defaults?.rounded"
     :variant="config?.variant !== 'default' ? config?.variant : undefined"
     :class="{ 'text-none': !config?.uppercase, 'bg-surface': true }"
     :active="false"
@@ -44,7 +44,7 @@ defineProps<{
 
 const { locale } = useI18n()
 
-const { preview } = usePortalStore()
+const { portalConfig, preview } = usePortalStore()
 const { isExternalLink, resolveLink, resolveLinkTitle } = useNavigationStore()
 
 </script>

--- a/portal/app/components/news/news-card.vue
+++ b/portal/app/components/news/news-card.vue
@@ -1,8 +1,8 @@
 <template>
   <v-card
     :to="!preview ? `/news/${pageConfig.newsMetadata?.slug}` : undefined"
-    :elevation="cardConfig.elevation ?? 0"
-    :rounded="cardConfig.rounded ?? 'default'"
+    :elevation="cardConfig.elevation ?? portalConfig.defaults?.elevation"
+    :rounded="cardConfig.rounded ?? portalConfig.defaults?.rounded"
     class="h-100 d-flex flex-column"
     link
   >
@@ -77,7 +77,7 @@ const { pageConfig, cardConfig, isPortalConfig } = defineProps<{
 }>()
 
 const { dayjs } = useLocaleDayjs()
-const { preview } = usePortalStore()
+const { portalConfig, preview } = usePortalStore()
 const { t } = useI18n()
 const getPageImageSrc = usePageImageSrc()
 const getPortalImageSrc = usePortalImageSrc()

--- a/portal/app/components/page-element/basic/page-element-contact.vue
+++ b/portal/app/components/page-element/basic/page-element-contact.vue
@@ -94,9 +94,9 @@
             <div class="d-flex justify-center">
               <v-btn
                 :color="buttonConfig?.color"
-                :density="buttonConfig?.density"
-                :elevation="buttonConfig?.elevation"
-                :rounded="buttonConfig?.rounded"
+                :density="buttonConfig?.density ?? portalConfig.defaults?.density"
+                :elevation="buttonConfig?.elevation ?? portalConfig.defaults?.elevation"
+                :rounded="buttonConfig?.rounded ?? portalConfig.defaults?.rounded"
                 :variant="valid ? (buttonConfig?.variant !== 'default' ? buttonConfig?.variant : undefined) : 'tonal'"
                 :class="{ 'text-none': !buttonConfig?.uppercase }"
                 :text="t('send')"

--- a/portal/app/components/page-element/layout/page-element-card.vue
+++ b/portal/app/components/page-element/layout/page-element-card.vue
@@ -14,8 +14,8 @@
     v-bind:title.attr="altLinkTitle"
 
     :border="element.border"
-    :elevation="element.elevation"
-    :rounded="element.rounded"
+    :rounded="element.rounded ?? portalConfig.defaults?.rounded"
+    :elevation="element.elevation ?? portalConfig.defaults?.elevation"
     :variant="element.background?.tonal ? 'tonal' : undefined"
     :class="[element.mb !== 0 && `mb-${element.mb ?? 4}`, 'd-flex flex-column flex-grow-1']"
     :color="element.background?.color"

--- a/portal/app/components/page-element/layout/page-element-expansion-panels.vue
+++ b/portal/app/components/page-element/layout/page-element-expansion-panels.vue
@@ -2,8 +2,8 @@
   <v-expansion-panels
     v-model="activePanels"
     :multiple="element.multiple"
-    :rounded="element.rounded"
-    :elevation="element.elevation"
+    :rounded="element.rounded ?? portalConfig.defaults?.rounded"
+    :elevation="element.elevation ?? portalConfig.defaults?.elevation"
     :color="element.titleBackgroundColor ?? 'surface'"
     :bg-color="element.textBackgroundColor"
 
@@ -47,7 +47,7 @@ const { element } = defineProps({
   element: { type: Object as () => ExpansionPanelsElement, required: true }
 })
 
-const { preview } = usePortalStore()
+const { preview, portalConfig } = usePortalStore()
 const activePanels = ref<number[] | number | null>(element.multiple ? [] : null)
 
 const count = element.panels.filter(Boolean).length

--- a/portal/app/components/reuse/reuse-card.vue
+++ b/portal/app/components/reuse/reuse-card.vue
@@ -5,8 +5,8 @@
   -->
   <v-card
     :to="!preview ? `/reuses/${reuse.slug}` : undefined "
-    :elevation="cardConfig.elevation ?? 0"
-    :rounded="cardConfig.rounded ?? 'default'"
+    :elevation="cardConfig.elevation ?? portalConfig.defaults?.elevation"
+    :rounded="cardConfig.rounded ?? portalConfig.defaults?.rounded"
     class="h-100 d-flex flex-column"
     link
   >
@@ -115,7 +115,7 @@ const { reuse, cardConfig, isPortalConfig } = defineProps<{
 
 const { dayjs } = useLocaleDayjs()
 const { t } = useI18n()
-const { preview } = usePortalStore()
+const { portalConfig, preview } = usePortalStore()
 const getPageImageSrc = usePageImageSrc()
 const getPortalImageSrc = usePortalImageSrc()
 

--- a/portal/app/components/topics-list.vue
+++ b/portal/app/components/topics-list.vue
@@ -19,9 +19,9 @@
       -->
       <v-chip
         :color="resolvedColor(topic.color)"
-        :density="config?.density"
-        :elevation="config?.elevation"
-        :rounded="config?.rounded"
+        :density="config?.density ?? portalConfig.defaults?.density"
+        :elevation="config?.elevation ?? portalConfig.defaults?.elevation"
+        :rounded="config?.rounded ?? portalConfig.defaults?.rounded"
         :link="isFilters || !!link"
         :to="(!preview && link && !isExternalLink(link)) ? `${resolveLink(link)}?topics=${topic.id}` : undefined"
         :variant="chipVariant(topic.id)"
@@ -43,10 +43,9 @@
 </template>
 
 <script setup lang="ts">
-import type { TopicsElement } from '#api/types/page-elements/index.ts'
-import type { LinkItem } from '#api/types/page-elements/index.ts'
+import type { TopicsElement, LinkItem } from '#api/types/page-elements/index.ts'
 
-const { preview } = usePortalStore()
+const { portalConfig, preview } = usePortalStore()
 const { isExternalLink, resolveLink } = useNavigationStore()
 const selected = useStringsArraySearchParam('topics')
 

--- a/ui/src/components/portal-preview-provider.vue
+++ b/ui/src/components/portal-preview-provider.vue
@@ -80,6 +80,11 @@ const portalConfigDefault: PortalConfig = {
   },
   navLinksConfig: {
     showIcon: true
+  },
+  defaults: {
+    elevation: 1,
+    density: 'comfortable',
+    rounded: 'default'
   }
 }
 

--- a/ui/src/components/reuses-actions.vue
+++ b/ui/src/components/reuses-actions.vue
@@ -82,7 +82,7 @@ const eventsSubscribeUrl = computed(() => {
   const topics = [{ key: 'reuses:reuse-submit', title: t('reuseSubmittedForValidation') }]
   const urlTemplate = window.parent.location.origin + '/data-fair/reuses/{reuseId}'
   const sender = encodeURIComponent(`${session.state.account.type}:${session.state.account.id}:*`)
-  return `/events/embed/subscribe?key=${encodeURIComponent(topics.map(t => t.key).join(','))}&title=${encodeURIComponent(topics.map(t => t.title).join(','))}&url-template=${encodeURIComponent(urlTemplate)}&&sender=${sender}register=false`
+  return `/events/embed/subscribe?key=${encodeURIComponent(topics.map(t => t.key).join(','))}&title=${encodeURIComponent(topics.map(t => t.title).join(','))}&url-template=${encodeURIComponent(urlTemplate)}&sender=${sender}&register=false`
 })
 
 </script>


### PR DESCRIPTION
Add a global configuration section in the portal settings to define default visual properties for the entire portal for **elevation**, **density** and **rounded**.

These global defaults can be overridden at the component level when needed, providing flexibility while maintaining consistency across the portal.

### Changes
- Add `defaults` property in portal-config schema with elevation, density, and rounded properties
- Update various card components to use these global defaults