### PR TITLE
feat: Add navigation and content agent tools in portal

### DIFF
--- a/portal/app/app.vue
+++ b/portal/app/app.vue
@@ -5,7 +5,7 @@
       <NuxtPage />
       <ClientOnly><UiNotif /></ClientOnly>
       <ClientOnly><AcceptCookies /></ClientOnly>
-      <ClientOnly><AgentChat :portal-config="$portal.config" :owner="$portal.owner" :locale="locale" :local-fetch="$localFetch" /></ClientOnly>
+      <ClientOnly><AgentChat :portal-config="$portal.config" :portal-id="$portal._id" :owner="$portal.owner" :locale="locale" :local-fetch="$localFetch" /></ClientOnly>
     </NuxtLayout>
   </v-app>
 </template>

--- a/portal/app/components/agent-chat.vue
+++ b/portal/app/components/agent-chat.vue
@@ -60,6 +60,9 @@ import type { $Fetch } from 'ofetch'
 import type { PortalConfig } from '#api/types/portal-config'
 import { useAgentDatasetTools } from '../composables/agent/dataset-tools'
 import { useAgentDatasetDataTools } from '../composables/agent/dataset-data-tools'
+import { useAgentNavigationTools } from '../composables/agent/navigation-tools'
+import { useAgentGeoTools } from '../composables/agent/geo-tools'
+import { useAgentPortalContentTools } from '../composables/agent/portal-content-tools'
 import { useFrameServer } from '@data-fair/lib-vue-agents'
 
 const DfAgentChatDrawer = defineAsyncComponent(() => import('@data-fair/lib-vuetify-agents/DfAgentChatDrawer.vue'))
@@ -68,6 +71,7 @@ const DfAgentChatMenu = defineAsyncComponent(() => import('@data-fair/lib-vuetif
 
 const props = defineProps<{
   portalConfig: PortalConfig
+  portalId: string
   owner: { type: string, id: string }
   locale: Ref<string>
   localFetch: $Fetch
@@ -84,6 +88,13 @@ watchEffect(() => {
       useFrameServer('portal')
       useAgentDatasetTools(props.locale, props.localFetch)
       useAgentDatasetDataTools(props.locale, props.localFetch)
+      useAgentNavigationTools({
+        locale: props.locale,
+        portalConfig: props.portalConfig,
+        navigationStore: useNavigationStore()
+      })
+      useAgentGeoTools(props.locale)
+      useAgentPortalContentTools(props.locale, props.localFetch, props.portalId)
     })
   } else if (!agentChat.value?.active && toolsScope) {
     toolsScope.stop()

--- a/portal/app/composables/agent/geo-tools.ts
+++ b/portal/app/composables/agent/geo-tools.ts
@@ -1,0 +1,96 @@
+import type { Ref } from 'vue'
+import { useAgentTool } from '@data-fair/lib-vue-agents'
+import * as geocodeAddress from '@data-fair/agent-tools-data-fair/geocode-address'
+
+const getUserGeolocationTitle: Record<string, string> = {
+  fr: 'Obtenir la géolocalisation de l\'utilisateur',
+  en: 'Get user geolocation'
+}
+
+export function useAgentGeoTools (locale: Ref<string>) {
+  useAgentTool({
+    ...geocodeAddress.schema,
+    annotations: { title: (geocodeAddress.annotations as any)[locale.value]?.title ?? geocodeAddress.annotations.en.title, readOnlyHint: true },
+    execute: async (params) => {
+      let url: string
+      try {
+        url = geocodeAddress.buildUrl(params)
+      } catch (err: any) {
+        return {
+          content: [{ type: 'text' as const, text: err.message }],
+          isError: true
+        }
+      }
+
+      let data: any
+      try {
+        const res = await fetch(url)
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        data = await res.json()
+      } catch (err: any) {
+        return {
+          content: [{ type: 'text' as const, text: `Geocoding API error: ${err.message}` }],
+          isError: true
+        }
+      }
+
+      return {
+        content: [{ type: 'text' as const, text: geocodeAddress.formatResult(data, params).text }]
+      }
+    }
+  })
+
+  useAgentTool({
+    name: 'get_user_geolocation',
+    description: 'Get the current geographic position of the user using the browser Geolocation API. Returns latitude, longitude, and accuracy. The user may be prompted to grant location permission.',
+    annotations: { title: getUserGeolocationTitle[locale.value] ?? getUserGeolocationTitle.en, readOnlyHint: true },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {}
+    },
+    execute: async () => {
+      if (!navigator.geolocation) {
+        return {
+          content: [{ type: 'text' as const, text: 'Geolocation is not supported by this browser.' }],
+          isError: true
+        }
+      }
+
+      try {
+        const position = await new Promise<GeolocationPosition>((resolve, reject) => {
+          navigator.geolocation.getCurrentPosition(resolve, reject, {
+            enableHighAccuracy: true,
+            timeout: 10_000,
+            maximumAge: 60_000
+          })
+        })
+
+        const { latitude, longitude, accuracy, altitude, altitudeAccuracy } = position.coords
+        const parts = [
+          `**Latitude**: ${latitude}`,
+          `**Longitude**: ${longitude}`,
+          `**Accuracy**: ${Math.round(accuracy)} m`
+        ]
+        if (altitude != null) {
+          parts.push(`**Altitude**: ${altitude} m`)
+          if (altitudeAccuracy != null) parts.push(`**Altitude accuracy**: ${Math.round(altitudeAccuracy)} m`)
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: parts.join('\n') }]
+        }
+      } catch (err: any) {
+        const messages: Record<number, string> = {
+          1: 'Location permission denied by user.',
+          2: 'Position unavailable (location service error).',
+          3: 'Geolocation request timed out.'
+        }
+        const message = messages[err.code] || err.message || 'Unknown geolocation error.'
+        return {
+          content: [{ type: 'text' as const, text: message }],
+          isError: true
+        }
+      }
+    }
+  })
+}

--- a/portal/app/composables/agent/navigation-tools.ts
+++ b/portal/app/composables/agent/navigation-tools.ts
@@ -1,0 +1,179 @@
+import type { Ref } from 'vue'
+import type { VBreadcrumbs } from 'vuetify/components'
+import type { MenuItem } from '#api/types/portal/index.ts'
+import type { LinkItem } from '#api/types/common-links/index.ts'
+import type { PortalConfig } from '#api/types/portal-config'
+import { useAgentTool } from '@data-fair/lib-vue-agents'
+import { createAgentTranslator } from './utils'
+
+type BreadcrumbItems = NonNullable<VBreadcrumbs['$props']['items']>
+
+interface AgentNavigationStore {
+  breadcrumbs: Ref<BreadcrumbItems>
+  resolveLink: (link: MenuItem | LinkItem) => string | undefined
+  resolveLinkTitle: (link: MenuItem | LinkItem, locale: 'fr' | 'en') => string
+}
+
+const messages: Record<string, Record<string, string>> = {
+  fr: {
+    getCurrentLocation: 'Obtenir la localisation actuelle',
+    listPages: 'Lister les pages',
+    navigateToPage: 'Naviguer vers une page'
+  },
+  en: {
+    getCurrentLocation: 'Get current location',
+    listPages: 'List pages',
+    navigateToPage: 'Navigate to page'
+  }
+}
+
+interface AgentNavigationToolsDeps {
+  locale: Ref<string>
+  portalConfig: PortalConfig
+  navigationStore: AgentNavigationStore
+}
+
+export function useAgentNavigationTools ({ locale, portalConfig, navigationStore }: AgentNavigationToolsDeps) {
+  const t = createAgentTranslator(messages, locale)
+  const route = useRoute()
+  const router = useRouter()
+
+  useAgentTool({
+    name: 'get_current_location',
+    description: 'Get the current page location in the portal, including route path, name, parameters, query, and breadcrumbs.',
+    annotations: { title: t('getCurrentLocation'), readOnlyHint: true },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {}
+    },
+    execute: async () => {
+      const breadcrumbs = navigationStore.breadcrumbs.value
+        .map(b => {
+          if (typeof b === 'string') return `- ${b}`
+          const title = b.title || ''
+          const path = b.to ? (typeof b.to === 'string' ? b.to : router.resolve(b.to).href) : b.href || ''
+          return `- ${title}: ${path}`
+        })
+        .join('\n')
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `**Path**: ${route.path}\n**Name**: ${route.name as string}\n**Params**: ${JSON.stringify({ ...route.params })}\n**Query**: ${JSON.stringify({ ...route.query })}\n**Breadcrumbs**:\n${breadcrumbs}`
+        }]
+      }
+    }
+  })
+
+  useAgentTool({
+    name: 'list_pages',
+    description: 'List all available pages in the portal navigation menu, plus detail page patterns for datasets, applications, events, news, and reuses.',
+    annotations: { title: t('listPages'), readOnlyHint: true },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {}
+    },
+    execute: async () => {
+      const localeVal = (locale.value === 'fr' || locale.value === 'en') ? locale.value : 'fr'
+      const sections: string[] = []
+
+      // Walk menu items recursively
+      const formatMenuItems = (items: MenuItem[], indent = ''): string[] => {
+        const lines: string[] = []
+        for (const item of items) {
+          if (item.type === 'submenu') {
+            const title = item.title || 'Submenu'
+            lines.push(`${indent}- ${title} (submenu):`)
+            if (item.children) {
+              lines.push(...formatMenuItems(item.children, indent + '  '))
+            }
+          } else {
+            const title = navigationStore.resolveLinkTitle(item, localeVal)
+            const path = navigationStore.resolveLink(item)
+            if (path && item.type !== 'external') {
+              lines.push(`${indent}- ${title}: ${path}`)
+            } else if (path && item.type === 'external') {
+              lines.push(`${indent}- ${title}: ${path} (external)`)
+            }
+          }
+        }
+        return lines
+      }
+
+      const menuLines = formatMenuItems(portalConfig.menu.children as MenuItem[])
+      if (menuLines.length > 0) {
+        sections.push(`**Navigation menu**:\n${menuLines.join('\n')}`)
+      }
+
+      sections.push(
+        '**Detail pages** (use list_datasets, list_applications, list_events, list_news, or list_reuses to find slugs/refs):\n' +
+        '- Dataset detail: /datasets/{ref}\n' +
+        '- Dataset table: /datasets/{ref}/table\n' +
+        '- Dataset map: /datasets/{ref}/map\n' +
+        '- Dataset API doc: /datasets/{ref}/api-doc\n' +
+        '- Application detail: /applications/{ref}\n' +
+        '- Application full view: /applications/{ref}/full\n' +
+        '- Event detail: /event/{slug}\n' +
+        '- News detail: /news/{slug}\n' +
+        '- Reuse detail: /reuses/{slug}'
+      )
+
+      sections.push(
+        '**User pages**:\n' +
+        '- My account: /me\n' +
+        '- My reuses: /me/reuses\n' +
+        '- Update dataset: /me/update-dataset\n' +
+        '- My processings: /me/processings\n' +
+        '- My notifications: /me/notifications'
+      )
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: sections.join('\n\n')
+        }]
+      }
+    }
+  })
+
+  useAgentTool({
+    name: 'navigate',
+    description: 'Navigate to a page in the portal. Use list_pages to discover available paths, and list_datasets, list_applications, list_events, list_news, or list_reuses to find resource slugs/refs. Optionally pass query parameters.',
+    annotations: { title: t('navigateToPage') },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        path: {
+          type: 'string' as const,
+          description: 'The path to navigate to (e.g. "/datasets", "/datasets/my-dataset", "/event/my-event")'
+        },
+        query: {
+          type: 'object' as const,
+          description: 'Optional query parameters as key-value string pairs to add to the URL.',
+          properties: {}
+        }
+      },
+      required: ['path'] as const
+    },
+    execute: async (params) => {
+      try {
+        await router.push(params.query ? { path: params.path, query: params.query as Record<string, string> } : params.path)
+        await new Promise(resolve => setTimeout(resolve, 500))
+        const currentRoute = router.currentRoute.value
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `**Success**: true\n**New Path**: ${currentRoute.path}\n**Query**: ${JSON.stringify({ ...currentRoute.query })}`
+          }]
+        }
+      } catch (error: any) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `**Success**: false\n**Error**: ${error.message}`
+          }],
+          isError: true
+        }
+      }
+    }
+  })
+}

--- a/portal/app/composables/agent/portal-content-tools.ts
+++ b/portal/app/composables/agent/portal-content-tools.ts
@@ -1,0 +1,171 @@
+import type { Ref } from 'vue'
+import type { $Fetch } from 'ofetch'
+import { useAgentTool } from '@data-fair/lib-vue-agents'
+import { createAgentTranslator, agentToolError } from './utils'
+
+const messages: Record<string, Record<string, string>> = {
+  fr: {
+    listApplications: 'Lister les visualisations',
+    listEvents: 'Lister les événements',
+    listNews: 'Lister les actualités',
+    listReuses: 'Lister les réutilisations'
+  },
+  en: {
+    listApplications: 'List applications',
+    listEvents: 'List events',
+    listNews: 'List news',
+    listReuses: 'List reuses'
+  }
+}
+
+export function useAgentPortalContentTools (locale: Ref<string>, localFetch: $Fetch, portalId: string) {
+  const t = createAgentTranslator(messages, locale)
+
+  useAgentTool({
+    name: 'list_applications',
+    description: 'List data visualizations (applications) published on this portal. Returns title, slug, and summary for each application.',
+    annotations: { title: t('listApplications'), readOnlyHint: true },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        q: { type: 'string' as const, description: 'Optional full-text search query' },
+        size: { type: 'number' as const, description: 'Number of results to return (default 10, max 50)' },
+        page: { type: 'number' as const, description: 'Page number (default 1)' }
+      }
+    },
+    execute: async (params) => {
+      try {
+        const size = Math.min(Math.max(params.size || 10, 1), 50)
+        const page = Math.max(params.page || 1, 1)
+        const query: Record<string, string> = {
+          select: 'id,slug,title,summary,updatedAt',
+          publicationSites: 'data-fair-portals:' + portalId,
+          size: String(size),
+          skip: String((page - 1) * size),
+          sort: 'createdAt:-1'
+        }
+        if (params.q) query.q = params.q
+
+        const data = await localFetch<any>('/data-fair/api/v1/applications', { query })
+        const items = (data.results || []).map((app: any) =>
+          `- **${app.title}** (ref: \`${app.slug || app.id}\`)${app.summary ? ` — ${app.summary}` : ''}`
+        )
+        const text = items.length > 0
+          ? `**Applications** (${data.count} total, showing page ${page}):\n${items.join('\n')}`
+          : 'No applications found.'
+        return { content: [{ type: 'text' as const, text }] }
+      } catch (err) {
+        return agentToolError('Failed to list applications', err)
+      }
+    }
+  })
+
+  useAgentTool({
+    name: 'list_events',
+    description: 'List events published on this portal. Returns title, slug, and dates for each event.',
+    annotations: { title: t('listEvents'), readOnlyHint: true },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        size: { type: 'number' as const, description: 'Number of results to return (default 10, max 50)' },
+        includePast: { type: 'boolean' as const, description: 'Include past events (default false, only upcoming events)' }
+      }
+    },
+    execute: async (params) => {
+      try {
+        const size = Math.min(Math.max(params.size || 10, 1), 50)
+        const query: Record<string, string> = {
+          size: String(size),
+          sort: 'startDate:1'
+        }
+        if (params.includePast) query.includePast = 'true'
+
+        const data = await localFetch<any>('/portal/api/events', { query })
+        const items = (data.results || []).map((event: any) => {
+          const meta = event.eventMetadata || {}
+          const dates = meta.startDate ? ` (${meta.startDate}${meta.endDate ? ' - ' + meta.endDate : ''})` : ''
+          return `- **${event.title}** (slug: \`${meta.slug}\`)${dates}`
+        })
+        const text = items.length > 0
+          ? `**Events** (${data.count} total):\n${items.join('\n')}`
+          : 'No events found.'
+        return { content: [{ type: 'text' as const, text }] }
+      } catch (err) {
+        return agentToolError('Failed to list events', err)
+      }
+    }
+  })
+
+  useAgentTool({
+    name: 'list_news',
+    description: 'List news articles published on this portal. Returns title, slug, and date for each article.',
+    annotations: { title: t('listNews'), readOnlyHint: true },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        q: { type: 'string' as const, description: 'Optional full-text search query' },
+        size: { type: 'number' as const, description: 'Number of results to return (default 10, max 50)' }
+      }
+    },
+    execute: async (params) => {
+      try {
+        const size = Math.min(Math.max(params.size || 10, 1), 50)
+        const query: Record<string, string> = {
+          size: String(size),
+          sort: 'date:-1'
+        }
+        if (params.q) query.q = params.q
+
+        const data = await localFetch<any>('/portal/api/news', { query })
+        const items = (data.results || []).map((news: any) => {
+          const meta = news.newsMetadata || {}
+          const date = meta.date ? ` (${meta.date})` : ''
+          return `- **${news.title}** (slug: \`${meta.slug}\`)${date}`
+        })
+        const text = items.length > 0
+          ? `**News** (${data.count} total):\n${items.join('\n')}`
+          : 'No news articles found.'
+        return { content: [{ type: 'text' as const, text }] }
+      } catch (err) {
+        return agentToolError('Failed to list news', err)
+      }
+    }
+  })
+
+  useAgentTool({
+    name: 'list_reuses',
+    description: 'List community reuses published on this portal. Returns title, slug, and summary for each reuse.',
+    annotations: { title: t('listReuses'), readOnlyHint: true },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        q: { type: 'string' as const, description: 'Optional full-text search query' },
+        size: { type: 'number' as const, description: 'Number of results to return (default 10, max 50)' }
+      }
+    },
+    execute: async (params) => {
+      try {
+        const size = Math.min(Math.max(params.size || 10, 1), 50)
+        const query: Record<string, string> = {
+          size: String(size),
+          sort: 'updatedAt:-1'
+        }
+        if (params.q) query.q = params.q
+
+        const data = await localFetch<any>('/portal/api/reuses', { query })
+        const items = (data.results || []).map((reuse: any) => {
+          const config = reuse.config || {}
+          const title = config.title || reuse.slug || reuse._id
+          const summary = config.summary ? ` — ${config.summary}` : ''
+          return `- **${title}** (slug: \`${reuse.slug}\`)${summary}`
+        })
+        const text = items.length > 0
+          ? `**Reuses** (${data.count} total):\n${items.join('\n')}`
+          : 'No reuses found.'
+        return { content: [{ type: 'text' as const, text }] }
+      } catch (err) {
+        return agentToolError('Failed to list reuses', err)
+      }
+    }
+  })
+}


### PR DESCRIPTION
  - Add navigation tools (get_current_location, list_pages, navigate) so the portal AI agent can discover available pages and navigate users to them                                      
  - Add geo tools (geocode_address, get_user_geolocation) for address geocoding and browser-based geolocation
  - Add portal content listing tools (list_applications, list_events, list_news, list_reuses) to let the agent browse published portal resources 