### PR TITLE
feat: restrict AI assistant visibility by user role

### DIFF
--- a/api/types/portal-config/schema.js
+++ b/api/types/portal-config/schema.js
@@ -481,6 +481,22 @@ export default {
           default: false,
           layout: 'switch'
         },
+        visibleTo: {
+          type: 'array',
+          title: 'Visible pour',
+          default: ['admin', 'contrib', 'user', 'external', 'anonymous'],
+          items: {
+            type: 'string',
+            oneOf: [
+              { const: 'admin', title: 'Administrateurs de l\'organisation' },
+              { const: 'contrib', title: 'Contributeurs de l\'organisation' },
+              { const: 'user', title: 'Autres membres de l\'organisation' },
+              { const: 'external', title: 'Utilisateurs externes authentifiés' },
+              { const: 'anonymous', title: 'Visiteurs anonymes' }
+            ]
+          },
+          layout: { if: 'parent.data?.active' }
+        },
         type: {
           type: 'string',
           title: 'Mode d\'affichage',

--- a/dev/resources/organizations.json
+++ b/dev/resources/organizations.json
@@ -46,10 +46,6 @@
         "role": "admin"
       },
       {
-        "id": "albanm",
-        "role": "contrib"
-      },
-      {
         "id": "test_superadmin",
         "role": "user"
       }
@@ -61,10 +57,6 @@
     "members": [
       {
         "id": "test_superadmin",
-        "role": "admin"
-      },
-      {
-        "id": "albanm",
         "role": "admin"
       },
       {
@@ -84,6 +76,16 @@
       {
         "id": "test_org1",
         "name": "Test Org 1"
+      }
+    ]
+  },
+  {
+    "id": "dev_org",
+    "name": "Dev Org",
+    "members": [
+      {
+        "id": "albanm",
+        "role": "admin"
       }
     ]
   }

--- a/portal/app/components/agent-chat.vue
+++ b/portal/app/components/agent-chat.vue
@@ -64,6 +64,7 @@ import { useAgentNavigationTools } from '../composables/agent/navigation-tools'
 import { useAgentGeoTools } from '../composables/agent/geo-tools'
 import { useAgentPortalContentTools } from '../composables/agent/portal-content-tools'
 import { useFrameServer } from '@data-fair/lib-vue-agents'
+import { type Account, getAccountRole } from '@data-fair/lib-common-types/session/index.js'
 
 const DfAgentChatDrawer = defineAsyncComponent(() => import('@data-fair/lib-vuetify-agents/DfAgentChatDrawer.vue'))
 const DfAgentChatToggle = defineAsyncComponent(() => import('@data-fair/lib-vuetify-agents/DfAgentChatToggle.vue'))
@@ -72,7 +73,7 @@ const DfAgentChatMenu = defineAsyncComponent(() => import('@data-fair/lib-vuetif
 const props = defineProps<{
   portalConfig: PortalConfig
   portalId: string
-  owner: { type: string, id: string, name: string }
+  owner: Account
   locale: Ref<string>
   localFetch: $Fetch
 }>()
@@ -83,16 +84,9 @@ const owner = computed(() => props.owner)
 const session = useSession()
 
 const viewerBucket = computed<'admin' | 'contrib' | 'user' | 'external' | 'anonymous'>(() => {
-  const user = session.user.value
-  if (!user) return 'anonymous'
-  const account = session.account.value
-  if (account && account.type === props.owner.type && account.id === props.owner.id) {
-    const role = session.accountRole.value
-    if (role === 'admin') return 'admin'
-    if (role === 'contrib') return 'contrib'
-    return 'user'
-  }
-  return 'external'
+  if (!session.state.user) return 'anonymous'
+  const role = getAccountRole(session.state, props.owner, { acceptDepAsRoot: true }) as 'user' | 'contrib' | 'admin' | undefined
+  return role ?? 'external'
 })
 
 const canSee = computed(() => {

--- a/portal/app/components/agent-chat.vue
+++ b/portal/app/components/agent-chat.vue
@@ -1,5 +1,5 @@
 <template>
-  <template v-if="agentChat?.active && owner">
+  <template v-if="agentChat?.active && canSee && owner">
     <template v-if="agentChat.type === 'drawer'">
       <DfAgentChatDrawer
         :account-type="owner.type"
@@ -80,6 +80,27 @@ const props = defineProps<{
 const agentChat = computed(() => props.portalConfig.agentChat)
 const owner = computed(() => props.owner)
 
+const session = useSession()
+
+const viewerBucket = computed<'admin' | 'contrib' | 'user' | 'external' | 'anonymous'>(() => {
+  const user = session.user.value
+  if (!user) return 'anonymous'
+  const account = session.account.value
+  if (account && account.type === props.owner.type && account.id === props.owner.id) {
+    const role = session.accountRole.value
+    if (role === 'admin') return 'admin'
+    if (role === 'contrib') return 'contrib'
+    return 'user'
+  }
+  return 'external'
+})
+
+const canSee = computed(() => {
+  const visibleTo = agentChat.value?.visibleTo
+  if (!visibleTo) return true
+  return visibleTo.includes(viewerBucket.value)
+})
+
 const systemPrompt = computed(() => {
   const base = agentChat.value?.systemPrompt || ''
   const domain = import.meta.client ? window.location.hostname : ''
@@ -93,7 +114,7 @@ const systemPrompt = computed(() => {
 
 let toolsScope: ReturnType<typeof effectScope> | null = null
 watchEffect(() => {
-  if (agentChat.value?.active && !toolsScope) {
+  if (agentChat.value?.active && canSee.value && !toolsScope) {
     toolsScope = effectScope()
     toolsScope.run(() => {
       useFrameServer('portal')
@@ -107,7 +128,7 @@ watchEffect(() => {
       useAgentGeoTools(props.locale)
       useAgentPortalContentTools(props.locale, props.localFetch, props.portalId)
     })
-  } else if (!agentChat.value?.active && toolsScope) {
+  } else if ((!agentChat.value?.active || !canSee.value) && toolsScope) {
     toolsScope.stop()
     toolsScope = null
   }

--- a/tests/features/portal-rendering/agent-chat-visibility.e2e.spec.ts
+++ b/tests/features/portal-rendering/agent-chat-visibility.e2e.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '../../fixtures/portal.ts'
+import { axiosAuth, clean } from '../../support/axios.ts'
+
+const user1 = await axiosAuth('test_admin@test.com')
+
+test.describe('agent chat visibility', () => {
+  test.beforeEach(clean)
+
+  test('anonymous visitor sees the toggle when visibleTo includes anonymous', async ({ page, goToPortal }) => {
+    const portal = (await user1.post('/api/portals', {
+      config: {
+        title: 'Agent Chat Anon Visible',
+        menu: { children: [] },
+        agentChat: { active: true, visibleTo: ['anonymous'] }
+      }
+    })).data
+    await user1.post('/api/pages', {
+      type: 'home',
+      config: { title: 'Home', elements: [{ type: 'title', content: 'Hello', titleSize: 'h2' }] },
+      portals: [portal._id],
+      owner: portal.owner
+    })
+
+    await goToPortal(portal._id)
+    await expect(page.getByText('Hello')).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('.df-agent-chat-toggle')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('anonymous visitor does not see the toggle when visibleTo excludes anonymous', async ({ page, goToPortal }) => {
+    const portal = (await user1.post('/api/portals', {
+      config: {
+        title: 'Agent Chat Anon Hidden',
+        menu: { children: [] },
+        agentChat: { active: true, visibleTo: ['admin'] }
+      }
+    })).data
+    await user1.post('/api/pages', {
+      type: 'home',
+      config: { title: 'Home', elements: [{ type: 'title', content: 'Hello', titleSize: 'h2' }] },
+      portals: [portal._id],
+      owner: portal.owner
+    })
+
+    await goToPortal(portal._id)
+    await expect(page.getByText('Hello')).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('.df-agent-chat-toggle')).toHaveCount(0)
+  })
+})

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -23,6 +23,8 @@ export default defineConfig({
       'debug',
       'easymde',
       ...commonjsDeps,
+      'ajv-i18n/localize/en/index.js',
+      'ajv-i18n/localize/fr/index.js',
       '@data-fair/frame/lib/d-frame.js',
       '@data-fair/frame/lib/vue-router/use-parent-url.js',
       '@data-fair/lib-common-types/theme/index.js',

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
   // pre-bundle dependencies to avoid full page reloads during dev
   // cf https://vite.dev/guide/dep-pre-bundling.html
   optimizeDeps: {
+    // no discovery to prevent page reloads that break e2e tests
+    noDiscovery: true,
     include: [
       'debug',
       'easymde',


### PR DESCRIPTION
  - Adds a visibleTo config field on agentChat in the portal config schema, letting admins pick which audience buckets (admin/contrib/user/external/anonymous) can
   see the assistant.
  - portal/app/components/agent-chat.vue computes the viewer's bucket from session account/role and gates both rendering and tool registration on canSee.
  - Adds an e2e spec agent-chat-visibility.e2e.spec.ts covering the visibility rules, plus minor dev setup tweaks (organizations fixture, vite config).