### PR TITLE
feat: delegate colors preview to shared lib-vuetify component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -948,9 +948,9 @@
       "license": "MIT"
     },
     "node_modules/@data-fair/lib-common-types": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@data-fair/lib-common-types/-/lib-common-types-1.20.2.tgz",
-      "integrity": "sha512-nu7VVqBowq1ViHGdXoaQxZObti/axxYNTCXiHK/wDSkDy4ZmQ923X/RSTUe9vdr/1L/bIEJRL5LkdatA4vzrUA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/@data-fair/lib-common-types/-/lib-common-types-1.20.6.tgz",
+      "integrity": "sha512-9FJFyK0Q0p+1xxuiEjDJvfAOzgZIDWt6hJAe+mjYqcR1fa9jmB/eg4JdzOqyo4YCpsisQ634CYKhkJXnpT7izA==",
       "license": "MIT",
       "dependencies": {
         "@data-fair/lib-utils": "^1.6.1",
@@ -1143,9 +1143,9 @@
       }
     },
     "node_modules/@data-fair/lib-vuetify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@data-fair/lib-vuetify/-/lib-vuetify-2.1.0.tgz",
-      "integrity": "sha512-TrswJkAyVBrpyJJUkvlB2ZjnuaxvHL+w0wweo2jsxdcX4J40DwOVpBgMRZJfnSpWEzpT0FQ/kFwY39oZtvq9tg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@data-fair/lib-vuetify/-/lib-vuetify-2.2.0.tgz",
+      "integrity": "sha512-QzJROqSBBmRkIx9/tjqRoPEbWMEZ5uhy1PwJ1x2grsTcqJ7dxTWq1Fvm8LcEtwnOhoJAJu6E95WKyHFUhLAXNQ==",
       "license": "MIT",
       "dependencies": {
         "@data-fair/lib-common-types": "^1.10.4",

--- a/ui/src/components/portal-edit/colors-preview.vue
+++ b/ui/src/components/portal-edit/colors-preview.vue
@@ -1,128 +1,23 @@
 <template>
-  <v-alert
-    v-for="(warning, i) of colorsWarnings"
-    :key="i"
-    type="warning"
-    variant="outlined"
-    class="mb-2"
-  >
-    {{ warning }}
-  </v-alert>
   <preview :colors-key="colorsKey">
-    <component
-      :is="'style'"
-      v-if="colors"
-      :nonce="$cspNonce"
-    >
-      {{ getTextColorsCss(colors, 'preview-' + colorsKey) }}
-    </component>
-
-    <v-row density="compact">
-      <v-col>
-        <v-card
-          class="h-100"
-          :title="t('cardExample.title')"
-          :text="t('cardExample.text')"
-        />
-      </v-col>
-      <v-col>
-        <v-card
-          class="h-100"
-          :title="t('cardExample.title')"
-          :text="t('cardExample.textInverse')"
-          color="surface-inverse"
-        />
-      </v-col>
-    </v-row>
-
-    <v-row
-      v-for="color of colorKeys"
-      :key="color"
-      density="compact"
-    >
-      <v-col
-        v-for="variant of buttonVariants"
-        :key="variant"
-      >
-        <v-btn
-          :color="color"
-          :variant="variant"
-          block
-        >
-          {{ color }}
-        </v-btn>
-      </v-col>
-      <v-col>
-        <v-icon
-          :icon="mdiEmoticonKissOutline"
-          :color="color"
-        />
-      </v-col>
-    </v-row>
+    <lib-colors-preview
+      :colors-key="colorsKey"
+      :theme="theme"
+      :default-theme="defaultTheme"
+      :dark="dark"
+      :csp-nonce="$cspNonce"
+    />
   </preview>
 </template>
 
 <script setup lang="ts">
-import { useTheme } from 'vuetify'
-import type { VBtn } from 'vuetify/components/VBtn'
-import type { Colors, Theme } from '@data-fair/lib-common-types/theme/index.js'
-import { mdiEmoticonKissOutline } from '@mdi/js'
-import { defaultTheme, fillTheme, getTextColorsCss, getColorsWarnings, readableOptions, hcReadableOptions } from '@data-fair/lib-common-types/theme/index.js'
+import LibColorsPreview from '@data-fair/lib-vuetify/colors-preview.vue'
+import type { Theme } from '@data-fair/lib-common-types/theme/index.js'
+import { defaultTheme } from '@data-fair/lib-common-types/theme/index.js'
 
-const { t } = useI18n()
-const vuetifyTheme = useTheme()
-const { colorsKey, theme, dark } = defineProps({
+defineProps({
   colorsKey: { type: String as () => 'colors' | 'darkColors' | 'hcColors' | 'hcDarkColors', required: true },
   theme: { type: Object as () => Theme, required: true },
   dark: { type: Boolean, default: false }
 })
-
-const fullTheme = computed(() => {
-  return fillTheme(theme, defaultTheme)
-})
-
-const colors = computed(() => fullTheme.value?.[colorsKey])
-
-watch(fullTheme, () => {
-  if (!fullTheme.value) return
-  const key = 'preview-' + colorsKey
-  const colors = fullTheme.value[colorsKey]
-  if (vuetifyTheme.themes.value[key]) {
-    for (const color of Object.keys(vuetifyTheme.themes.value[key].colors)) {
-      if (colors[color as keyof Colors] === undefined) delete vuetifyTheme.themes.value[key].colors[color]
-    }
-    Object.assign(vuetifyTheme.themes.value[key].colors, colors)
-  } else {
-    vuetifyTheme.themes.value[key] = { dark, colors, variables: dark ? vuetifyTheme.themes.value.dark.variables : vuetifyTheme.themes.value.light.variables }
-  }
-}, { immediate: true })
-
-const buttonVariants: VBtn['variant'][] = ['flat', 'text']
-const colorKeys = ['primary', 'secondary', 'accent', 'info', 'success', 'error', 'warning']
-
-const themeNames = {
-  colors: 'default',
-  darkColors: 'dark',
-  hcColors: 'hc',
-  hcDarkColors: 'hcDark'
-}
-
-const colorsWarnings = computed(() => {
-  return getColorsWarnings('fr', colors.value, themeNames[colorsKey], colorsKey.startsWith('hc') ? hcReadableOptions : readableOptions)
-})
 </script>
-
-<i18n lang="yaml">
-  en:
-    cardExample:
-      title: Card example
-      text: Surface color.
-      textInverse: Inverse surface color.
-
-  fr:
-    cardExample:
-      title: Vignette
-      text: Couleur des surfaces.
-      textInverse: Couleur inversée des surfaces.
-
-</i18n>

--- a/ui/src/components/portal-edit/preview.vue
+++ b/ui/src/components/portal-edit/preview.vue
@@ -18,7 +18,7 @@
             <slot name="prepend" />
           </template>
         </v-card-title>
-        <v-card-text :class="noPadding ? 'pa-0 bg-background' : 'pt-4 bg-background'">
+        <v-card-text :class="noPadding ? 'pa-0 bg-background' : 'pa-2 bg-background'">
           <slot />
         </v-card-text>
       </v-card>


### PR DESCRIPTION
  - Replaces the local colors-preview.vue implementation with the shared @data-fair/lib-vuetify/colors-preview.vue component, dropping ~100 lines of duplicated   
  preview logic (theme injection, warnings, button/card samples, i18n).                                                                                           
  - Relies on the latest defaultTheme from @data-fair/lib-common-types so portal theming stays in sync with other Data FAIR apps.                                 
  - Tightens preview card padding (pt-4 → pa-2) for a more compact layout.   