### PR TITLE
feat: improve management of portals publication permission modes

### DIFF
--- a/api/doc/portals/patch-req-body/schema.js
+++ b/api/doc/portals/patch-req-body/schema.js
@@ -3,7 +3,7 @@ import portalSchema from '#types/portal/schema.js'
 
 export default {
   ...jsonSchema(portalSchema)
-    .pickProperties(['draftConfig', 'owner', 'isReference', 'whiteLabel', 'md2Compat'])
+    .pickProperties(['draftConfig', 'owner', 'isReference', 'whiteLabel', 'md2Compat', 'sharedWithDepartments'])
     .removeRequired()
     .schema,
   $id: 'https://github.com/data-fair/portals/portals/patch-req-body',

--- a/api/doc/portals/patch-req-body/schema.js
+++ b/api/doc/portals/patch-req-body/schema.js
@@ -3,7 +3,7 @@ import portalSchema from '#types/portal/schema.js'
 
 export default {
   ...jsonSchema(portalSchema)
-    .pickProperties(['draftConfig', 'owner', 'isReference', 'whiteLabel', 'md2Compat', 'sharedWithDepartments'])
+    .pickProperties(['draftConfig', 'owner', 'isReference', 'whiteLabel', 'md2Compat', 'staging', 'contributorDepartments'])
     .removeRequired()
     .schema,
   $id: 'https://github.com/data-fair/portals/portals/patch-req-body',

--- a/api/doc/portals/post-req-body/schema.js
+++ b/api/doc/portals/post-req-body/schema.js
@@ -8,7 +8,7 @@ const configSchema = jsonSchema(portalConfigSchema)
   .schema
 
 const schema = jsonSchema(portalSchema)
-  .pickProperties(['staging', 'owner', 'config'])
+  .pickProperties(['owner', 'config'])
   .removeFromRequired(['owner'])
   .addProperty('config', configSchema)
   .addProperty('sourcePortalId', { type: 'string', description: 'ID of the portal to duplicate' })

--- a/api/src/portals/router.ts
+++ b/api/src/portals/router.ts
@@ -10,7 +10,7 @@ import * as patchReqBody from '#doc/portals/patch-req-body/index.ts'
 import * as postIngressReqBody from '#types/portal-ingress/index.ts'
 import { httpError, reqSessionAuthenticated, assertAccountRole, assertAdminMode, reqOrigin } from '@data-fair/lib-express'
 import { defaultTheme, fillTheme } from '@data-fair/lib-common-types/theme/index.js'
-import { createPortal, validatePortalDraft, cancelPortalDraft, getPortalAsAdmin, patchPortal, deletePortal, sendPortalEvent, duplicatePortalConfig } from './service.ts'
+import { createPortal, validatePortalDraft, cancelPortalDraft, getPortal, getPortalAsAdmin, patchPortal, deletePortal, sendPortalEvent, duplicatePortalConfig } from './service.ts'
 
 const router = Router()
 export default router
@@ -126,7 +126,7 @@ router.post('', async (req, res, next) => {
 })
 
 router.get('/:id', async (req, res, next) => {
-  res.send(await getPortalAsAdmin(reqSessionAuthenticated(req), req.params.id))
+  res.send(await getPortal(reqSessionAuthenticated(req), req.params.id))
 })
 
 /**

--- a/api/src/portals/router.ts
+++ b/api/src/portals/router.ts
@@ -26,7 +26,7 @@ router.get('', async (req, res, next) => {
   const filters = findUtils.query(params)
 
   // If isReference=true, we get all references portals, without owner filter
-  const query = params.isReference === 'true' ? { isReference: true } : findUtils.filterPermissions(params, session)
+  const query = params.isReference === 'true' ? { isReference: true } : findUtils.filterPermissions(params, session, { contributorDepartments: true })
   const queryWithFilters = Object.assign(filters, query)
 
   // TODO: account filter for super admins ?

--- a/api/src/portals/service.ts
+++ b/api/src/portals/service.ts
@@ -4,7 +4,7 @@ import type { IngressManagerIngressInfo } from '#types'
 
 import debugModule from 'debug'
 import equal from 'fast-deep-equal'
-import { type SessionStateAuthenticated, assertAccountRole, assertAdminMode, httpError } from '@data-fair/lib-express'
+import { type SessionStateAuthenticated, assertAccountRole, assertAdminMode, getAccountRole, httpError } from '@data-fair/lib-express'
 import axios from '@data-fair/lib-node/axios.js'
 import eventsQueue from '@data-fair/lib-node/events-queue.js'
 import { defaultTheme, fillTheme } from '@data-fair/lib-common-types/theme/index.js'
@@ -22,6 +22,30 @@ export const getPortalAsAdmin = async (sessionState: SessionStateAuthenticated, 
   if (!portal) throw httpError(404, `portal "${id}" not found`)
   assertAccountRole(sessionState, portal.owner, 'admin')
   return portal
+}
+
+// Like getPortalAsAdmin but also accepts contrib role and contributorDepartments
+// inheritance (a department member with admin/contrib role can read an org-root
+// portal whose contributorDepartments includes their department).
+// Used for read-only routes — write routes still require getPortalAsAdmin.
+export const getPortal = async (sessionState: SessionStateAuthenticated, id: string) => {
+  const portal = await mongo.portals.findOne({ _id: id })
+  if (!portal) throw httpError(404, `portal "${id}" not found`)
+
+  const directRole = getAccountRole(sessionState, portal.owner)
+  if (directRole === 'admin' || directRole === 'contrib') return portal
+
+  if (
+    !portal.owner.department &&
+    portal.contributorDepartments?.length &&
+    sessionState.account.type === portal.owner.type &&
+    sessionState.account.id === portal.owner.id &&
+    sessionState.account.department &&
+    portal.contributorDepartments.includes(sessionState.account.department) &&
+    (sessionState.accountRole === 'admin' || sessionState.accountRole === 'contrib')
+  ) return portal
+
+  throw httpError(403, 'requires admin, contrib role(s)')
 }
 
 export const createPortal = async (portal: Portal, reqOrigin: string, cookie?: string) => {

--- a/api/src/portals/service.ts
+++ b/api/src/portals/service.ts
@@ -139,8 +139,10 @@ const getPublicationSite = (portal: Portal) => {
   if (portal.config && portal.config.authentication === 'required') {
     publicationSite.private = true
   }
-  publicationSite.contributorDepartments = portal.contributorDepartments || []
-  publicationSite.settings = { staging: !!portal.staging }
+  publicationSite.settings = {
+    staging: !!portal.staging,
+    contributorDepartments: portal.contributorDepartments || []
+  }
   return publicationSite
 }
 

--- a/api/src/portals/service.ts
+++ b/api/src/portals/service.ts
@@ -36,8 +36,8 @@ export const patchPortal = async (portal: Portal, patch: Partial<Portal>, sessio
   // Change WhiteLabel, isReference or md2Compat by super admin only
   if (patch.whiteLabel || patch.isReference || patch.md2Compat) assertAdminMode(session)
 
-  if (patch.sharedWithDepartments && patch.sharedWithDepartments.length && portal.owner.department) {
-    throw httpError(400, 'sharedWithDepartments is only allowed when the portal owner is the organisation root')
+  if (patch.contributorDepartments && patch.contributorDepartments.length && portal.owner.department) {
+    throw httpError(400, 'contributorDepartments is only allowed when the portal owner is the organisation root')
   }
 
   // Change of ownership - Check permissions and propagate to images
@@ -139,7 +139,8 @@ const getPublicationSite = (portal: Portal) => {
   if (portal.config && portal.config.authentication === 'required') {
     publicationSite.private = true
   }
-  publicationSite.sharedWithDepartments = portal.sharedWithDepartments || []
+  publicationSite.contributorDepartments = portal.contributorDepartments || []
+  publicationSite.settings = { staging: !!portal.staging }
   return publicationSite
 }
 

--- a/api/src/portals/service.ts
+++ b/api/src/portals/service.ts
@@ -135,6 +135,7 @@ const getPublicationSite = (portal: Portal) => {
   if (portal.config && portal.config.authentication === 'required') {
     publicationSite.private = true
   }
+  publicationSite.sharedWithDepartments = portal.sharedWithDepartments || []
   return publicationSite
 }
 

--- a/api/src/portals/service.ts
+++ b/api/src/portals/service.ts
@@ -36,6 +36,10 @@ export const patchPortal = async (portal: Portal, patch: Partial<Portal>, sessio
   // Change WhiteLabel, isReference or md2Compat by super admin only
   if (patch.whiteLabel || patch.isReference || patch.md2Compat) assertAdminMode(session)
 
+  if (patch.sharedWithDepartments && patch.sharedWithDepartments.length && portal.owner.department) {
+    throw httpError(400, 'sharedWithDepartments is only allowed when the portal owner is the organisation root')
+  }
+
   // Change of ownership - Check permissions and propagate to images
   if (patch.owner) {
     assertAccountRole(session, patch.owner, 'admin')

--- a/api/src/utils/find.ts
+++ b/api/src/utils/find.ts
@@ -2,9 +2,15 @@ import { mongoPagination, mongoProjection, mongoSort, type SessionStateAuthentic
 import { httpError } from '@data-fair/lib-utils/http-errors.js'
 
 /**
- * Show all if super admin, otherwise filter by owner
+ * Show all if super admin, otherwise filter by owner.
+ * When `contributorDepartments` is true, also include org-root resources whose
+ * `contributorDepartments` array contains the session's department.
  */
-export const filterPermissions = (reqQuery: Record<string, string>, sessionState: SessionStateAuthenticated) => {
+export const filterPermissions = (
+  reqQuery: Record<string, string>,
+  sessionState: SessionStateAuthenticated,
+  options: { contributorDepartments?: boolean } = {}
+) => {
   const query: Record<string, any> = {}
 
   const showAll = reqQuery.showAll === 'true'
@@ -13,7 +19,16 @@ export const filterPermissions = (reqQuery: Record<string, string>, sessionState
   if (!showAll) {
     query['owner.type'] = sessionState.account.type
     query['owner.id'] = sessionState.account.id
-    if (sessionState.account.department) query['owner.department'] = sessionState.account.department
+    if (sessionState.account.department) {
+      if (options.contributorDepartments) {
+        query.$or = [
+          { 'owner.department': sessionState.account.department },
+          { 'owner.department': { $exists: false }, contributorDepartments: sessionState.account.department }
+        ]
+      } else {
+        query['owner.department'] = sessionState.account.department
+      }
+    }
   }
   return query
 }

--- a/api/src/utils/find.ts
+++ b/api/src/utils/find.ts
@@ -2,9 +2,46 @@ import { mongoPagination, mongoProjection, mongoSort, type SessionStateAuthentic
 import { httpError } from '@data-fair/lib-utils/http-errors.js'
 
 /**
+ * Build a mongo filter from the `owner` query parameter, in the
+ * `type:id:dep[,...]` format used by data-fair.
+ *
+ * - department `*` (or omitted) → any department
+ * - department `-` → no department (org-root)
+ * - leading `-` on type → negation
+ */
+export const ownerFilters = (reqQuery: Record<string, string>) => {
+  const or: any[] = []
+  const nor: any[] = []
+  for (const ownerStr of reqQuery.owner.split(',')) {
+    const [typ, id, dep] = ownerStr.split(':')
+    const filter: Record<string, any> = { 'owner.type': typ.replace('-', ''), 'owner.id': id }
+    if (!dep || dep === '*') {
+      // no department filter to apply
+    } else if (dep === '-') {
+      filter['owner.department'] = { $exists: false }
+    } else {
+      filter['owner.department'] = dep
+    }
+    if (typ.startsWith('-')) nor.push(filter)
+    else or.push(filter)
+  }
+  const and: any[] = []
+  if (or.length) and.push({ $or: or })
+  if (nor.length) and.push({ $nor: nor })
+  return and
+}
+
+/**
  * Show all if super admin, otherwise filter by owner.
+ *
  * When `contributorDepartments` is true, also include org-root resources whose
  * `contributorDepartments` array contains the session's department.
+ *
+ * When the caller passes a `owner` query parameter (data-fair format
+ * `type:id:dep`), it is applied as an extra restriction on top of the
+ * session's permission filter and the contributorDepartments inclusion is
+ * skipped - this is how the portals list page narrows the listing to portals
+ * actually owned by the session's account.
  */
 export const filterPermissions = (
   reqQuery: Record<string, string>,
@@ -20,7 +57,7 @@ export const filterPermissions = (
     query['owner.type'] = sessionState.account.type
     query['owner.id'] = sessionState.account.id
     if (sessionState.account.department) {
-      if (options.contributorDepartments) {
+      if (options.contributorDepartments && !reqQuery.owner) {
         query.$or = [
           { 'owner.department': sessionState.account.department },
           { 'owner.department': { $exists: false }, contributorDepartments: sessionState.account.department }
@@ -30,6 +67,11 @@ export const filterPermissions = (
       }
     }
   }
+
+  if (reqQuery.owner) {
+    query.$and = ownerFilters(reqQuery)
+  }
+
   return query
 }
 

--- a/api/types/portal/schema.js
+++ b/api/types/portal/schema.js
@@ -41,9 +41,9 @@ export default {
       type: 'boolean',
       default: false
     },
-    sharedWithDepartments: {
+    contributorDepartments: {
       type: 'array',
-      title: 'Départements partagés',
+      title: 'Départements contributeurs',
       description: 'Départements dont les administrateurs peuvent publier sur ce portail, comme s\'ils en étaient propriétaires.',
       items: { type: 'string' },
       default: []

--- a/api/types/portal/schema.js
+++ b/api/types/portal/schema.js
@@ -41,6 +41,13 @@ export default {
       type: 'boolean',
       default: false
     },
+    sharedWithDepartments: {
+      type: 'array',
+      title: 'Départements partagés',
+      description: 'Départements dont les administrateurs peuvent publier sur ce portail, comme s\'ils en étaient propriétaires.',
+      items: { type: 'string' },
+      default: []
+    },
     owner: { $ref: 'https://github.com/data-fair/lib/account' },
     createdAt: { $ref: 'https://github.com/data-fair/portals/partial#/$defs/createdAt' },
     updatedAt: { $ref: 'https://github.com/data-fair/portals/partial#/$defs/updatedAt' },

--- a/dev/resources/organizations.json
+++ b/dev/resources/organizations.json
@@ -82,10 +82,25 @@
   {
     "id": "dev_org",
     "name": "Dev Org",
+    "departments": [
+      {
+        "id": "dev_dep1",
+        "name": "Department 1"
+      },
+      {
+        "id": "dev_dep2",
+        "name": "Department 2"
+      }
+    ],
     "members": [
       {
         "id": "albanm",
         "role": "admin"
+      },
+      {
+        "id": "dev_admin_dep",
+        "role": "admin",
+        "department": "dev_dep1"
       }
     ]
   }

--- a/dev/resources/users.json
+++ b/dev/resources/users.json
@@ -70,5 +70,14 @@
     "password": {
       "clear": "passwd"
     }
+  },
+  {
+    "id": "dev_admin_dep",
+    "firstName": "Dev",
+    "lastName": "Admin Dep",
+    "email": "dev_admin_dep@test.com",
+    "password": {
+      "clear": "passwd"
+    }
   }
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       CIPHER_PASSWORD: dev
       CONTACT: contact@test.com
       MANAGE_SITES: true
+      MANAGE_DEPARTMENTS: true
       MONGO_URL: mongodb://localhost:${MONGO_PORT}/simple-directory
       OBSERVER_ACTIVE: false
       PUBLIC_URL: http://${DEV_HOST}:${NGINX_PORT}/simple-directory
@@ -83,7 +84,7 @@ services:
     profiles:
       - dev
       - test
-    image: ghcr.io/data-fair/data-fair:master
+    image: ghcr.io/data-fair/data-fair:feat-publication-sites-permissions-mode
     restart: on-failure:10
     network_mode: host
     depends_on:

--- a/portal/app/layouts/personal.vue
+++ b/portal/app/layouts/personal.vue
@@ -11,6 +11,12 @@
   </ClientOnly>
 </template>
 
+<script setup lang="ts">
+useHead({
+  meta: [{ name: 'robots', content: 'noindex' }]
+})
+</script>
+
 <style>
 /* https://stackoverflow.com/questions/56973002/vuetify-adds-scrollbar-when-its-not-needed */
 html { overflow-y: auto; }

--- a/tests/features/pages/pages.api.spec.ts
+++ b/tests/features/pages/pages.api.spec.ts
@@ -7,6 +7,9 @@ import 'dotenv/config'
 import { clean, axiosAuth } from '../../support/axios.ts'
 
 const user1 = await axiosAuth('test_admin@test.com')
+const orgAdmin = await axiosAuth({ email: 'test_admin@test.com', org: 'test_org1' })
+const orgContrib = await axiosAuth({ email: 'test_contrib@test.com', org: 'test_org1' })
+const deptAdmin = await axiosAuth({ email: 'test_admin_dep@test.com', org: 'test_org1' })
 
 test.describe('pages management', () => {
   test.beforeEach(clean)
@@ -65,5 +68,58 @@ test.describe('pages management', () => {
     // Verify the duplicated image exists in database
     const duplicatedImageData = await user1.get(`/api/images/${duplicatedImageId}/data`)
     assert.equal(duplicatedImageData.status, 200, 'Duplicated image should be accessible')
+  })
+})
+
+test.describe('contributorDepartments page publication', () => {
+  test.beforeEach(clean)
+
+  test('dept admin publishes a dept-owned page on a non-staging org-root portal listed via contributorDepartments', async () => {
+    const sharedPortal = (await orgAdmin.post('/api/portals', { config: { title: 'Shared', menu: { children: [] } } })).data
+    await orgAdmin.patch(`/api/portals/${sharedPortal._id}`, { contributorDepartments: ['dep1'] })
+
+    const page = (await deptAdmin.post('/api/pages', { type: 'generic', title: 'Dept page', config: { title: 'Dept page', elements: [], genericMetadata: { slug: 'dept-page' } } })).data
+    assert.equal(page.owner.department, 'dep1')
+
+    const patched = (await deptAdmin.patch(`/api/pages/${page._id}`, { portals: [sharedPortal._id] })).data
+    assert.deepEqual(patched.portals, [sharedPortal._id])
+    assert.deepEqual(patched.requestedPortals, [])
+  })
+
+  test('dept admin requests publication of a dept-owned page on a staging org-root portal listed via contributorDepartments', async () => {
+    const stagingPortal = (await orgAdmin.post('/api/portals', { config: { title: 'Staging', menu: { children: [] } } })).data
+    await orgAdmin.patch(`/api/portals/${stagingPortal._id}`, { staging: true, contributorDepartments: ['dep1'] })
+
+    const page = (await deptAdmin.post('/api/pages', { type: 'generic', title: 'Dept page', config: { title: 'Dept page', elements: [], genericMetadata: { slug: 'dept-page' } } })).data
+
+    const patched = (await deptAdmin.patch(`/api/pages/${page._id}`, { requestedPortals: [stagingPortal._id] })).data
+    assert.deepEqual(patched.requestedPortals, [stagingPortal._id])
+    assert.deepEqual(patched.portals, [])
+
+    // org-root admin moves the request into actual publication
+    const accepted = (await orgAdmin.patch(`/api/pages/${page._id}`, { portals: [stagingPortal._id], requestedPortals: [] })).data
+    assert.deepEqual(accepted.portals, [stagingPortal._id])
+    assert.deepEqual(accepted.requestedPortals, [])
+  })
+})
+
+test.describe('staging publication flow', () => {
+  test.beforeEach(clean)
+
+  test('contrib can request publication via requestedPortals but cannot publish directly', async () => {
+    const portal = (await orgAdmin.post('/api/portals', { config: { title: 'Staging', menu: { children: [] } } })).data
+    await orgAdmin.patch(`/api/portals/${portal._id}`, { staging: true })
+    const page = (await orgAdmin.post('/api/pages', { type: 'generic', title: 'P', config: { title: 'P', elements: [], genericMetadata: { slug: 'p' } } })).data
+
+    // Contrib cannot patch portals directly
+    await assert.rejects(
+      orgContrib.patch(`/api/pages/${page._id}`, { portals: [portal._id] }),
+      (err: any) => err.status === 403 || err.status === 401
+    )
+
+    // Contrib can request publication
+    const requested = (await orgContrib.patch(`/api/pages/${page._id}`, { requestedPortals: [portal._id] })).data
+    assert.deepEqual(requested.requestedPortals, [portal._id])
+    assert.deepEqual(requested.portals, [])
   })
 })

--- a/tests/features/portals/portals.api.spec.ts
+++ b/tests/features/portals/portals.api.spec.ts
@@ -19,25 +19,40 @@ test.describe('portals management', () => {
     assert.deepEqual(portal.config, portal.draftConfig)
   })
 
-  test('org-root admin can set sharedWithDepartments on an org-root portal', async () => {
+  test('org-root admin can set contributorDepartments on an org-root portal', async () => {
     const portal = (await orgAdmin.post('/api/portals', { config: { title: 'P', menu: { children: [] } } })).data
-    const patched = (await orgAdmin.patch(`/api/portals/${portal._id}`, { sharedWithDepartments: ['dep1'] })).data
-    assert.deepEqual(patched.sharedWithDepartments, ['dep1'])
+    const patched = (await orgAdmin.patch(`/api/portals/${portal._id}`, { contributorDepartments: ['dep1'] })).data
+    assert.deepEqual(patched.contributorDepartments, ['dep1'])
   })
 
-  test('dept admin cannot set sharedWithDepartments on an org-root portal', async () => {
+  test('dept admin cannot set contributorDepartments on an org-root portal', async () => {
     const portal = (await orgAdmin.post('/api/portals', { config: { title: 'P', menu: { children: [] } } })).data
     await assert.rejects(
-      deptAdmin.patch(`/api/portals/${portal._id}`, { sharedWithDepartments: ['dep1'] }),
+      deptAdmin.patch(`/api/portals/${portal._id}`, { contributorDepartments: ['dep1'] }),
       (err: any) => err.status === 403 || err.status === 401
     )
   })
 
-  test('setting sharedWithDepartments on a dept-scoped portal is refused', async () => {
+  test('org-root admin can toggle staging after creation', async () => {
+    const portal = (await orgAdmin.post('/api/portals', { config: { title: 'P', menu: { children: [] } } })).data
+    assert.equal(portal.staging, false)
+    const patched = (await orgAdmin.patch(`/api/portals/${portal._id}`, { staging: true })).data
+    assert.equal(patched.staging, true)
+  })
+
+  test('dept admin cannot toggle staging on an org-root portal', async () => {
+    const portal = (await orgAdmin.post('/api/portals', { config: { title: 'P', menu: { children: [] } } })).data
+    await assert.rejects(
+      deptAdmin.patch(`/api/portals/${portal._id}`, { staging: true }),
+      (err: any) => err.status === 403 || err.status === 401
+    )
+  })
+
+  test('setting contributorDepartments on a dept-scoped portal is refused', async () => {
     const portal = (await deptAdmin.post('/api/portals', { config: { title: 'P', menu: { children: [] } } })).data
     assert.equal(portal.owner.department, 'dep1')
     await assert.rejects(
-      deptAdmin.patch(`/api/portals/${portal._id}`, { sharedWithDepartments: ['dep2'] }),
+      deptAdmin.patch(`/api/portals/${portal._id}`, { contributorDepartments: ['dep2'] }),
       (err: any) => err.status === 400
     )
   })

--- a/tests/features/portals/portals.api.spec.ts
+++ b/tests/features/portals/portals.api.spec.ts
@@ -70,6 +70,52 @@ test.describe('portals management', () => {
     assert.ok(!ids.includes(otherPortal._id), 'unrelated org-root portal should not be visible')
   })
 
+  test('dept admin with owner filter excludes contributorDepartments-shared portals', async () => {
+    const sharedPortal = (await orgAdmin.post('/api/portals', { config: { title: 'Shared', menu: { children: [] } } })).data
+    await orgAdmin.patch(`/api/portals/${sharedPortal._id}`, { contributorDepartments: ['dep1'] })
+    const ownPortal = (await deptAdmin.post('/api/portals', { config: { title: 'Own', menu: { children: [] } } })).data
+
+    const list = (await deptAdmin.get('/api/portals', { params: { owner: 'organization:test_org1:dep1' } })).data
+    const ids = list.results.map((p: any) => p._id)
+    assert.ok(!ids.includes(sharedPortal._id), 'contribute-only portal should be hidden with owner filter')
+    assert.ok(ids.includes(ownPortal._id), 'own dept portal should still be visible')
+  })
+
+  test('dept admin owner filter cannot escalate to a different account', async () => {
+    const otherOrgPortal = (await user1.post('/api/portals', { config: { title: 'OtherOrg', menu: { children: [] } } })).data
+
+    const list = (await deptAdmin.get('/api/portals', { params: { owner: `${otherOrgPortal.owner.type}:${otherOrgPortal.owner.id}` } })).data
+    const ids = list.results.map((p: any) => p._id)
+    assert.ok(!ids.includes(otherOrgPortal._id), 'owner filter must not bypass session permissions')
+  })
+
+  test('dept admin can GET an org-root portal shared via contributorDepartments', async () => {
+    const sharedPortal = (await orgAdmin.post('/api/portals', { config: { title: 'Shared', menu: { children: [] } } })).data
+    await orgAdmin.patch(`/api/portals/${sharedPortal._id}`, { contributorDepartments: ['dep1'] })
+
+    const fetched = (await deptAdmin.get(`/api/portals/${sharedPortal._id}`)).data
+    assert.equal(fetched._id, sharedPortal._id)
+  })
+
+  test('dept admin cannot GET an org-root portal not shared with their department', async () => {
+    const portal = (await orgAdmin.post('/api/portals', { config: { title: 'P', menu: { children: [] } } })).data
+
+    await assert.rejects(
+      deptAdmin.get(`/api/portals/${portal._id}`),
+      (err: any) => err.status === 403 || err.status === 401
+    )
+  })
+
+  test('dept admin via contributorDepartments cannot patch the portal', async () => {
+    const sharedPortal = (await orgAdmin.post('/api/portals', { config: { title: 'Shared', menu: { children: [] } } })).data
+    await orgAdmin.patch(`/api/portals/${sharedPortal._id}`, { contributorDepartments: ['dep1'] })
+
+    await assert.rejects(
+      deptAdmin.patch(`/api/portals/${sharedPortal._id}`, { config: { ...sharedPortal.config, title: 'Hacked' } }),
+      (err: any) => err.status === 403 || err.status === 401
+    )
+  })
+
   test('dept admin does not list org-root portal sharing a different department', async () => {
     const sharedPortal = (await orgAdmin.post('/api/portals', { config: { title: 'Shared', menu: { children: [] } } })).data
     await orgAdmin.patch(`/api/portals/${sharedPortal._id}`, { contributorDepartments: ['dep2'] })

--- a/tests/features/portals/portals.api.spec.ts
+++ b/tests/features/portals/portals.api.spec.ts
@@ -35,7 +35,7 @@ test.describe('portals management', () => {
 
   test('org-root admin can toggle staging after creation', async () => {
     const portal = (await orgAdmin.post('/api/portals', { config: { title: 'P', menu: { children: [] } } })).data
-    assert.equal(portal.staging, false)
+    assert.ok(!portal.staging)
     const patched = (await orgAdmin.patch(`/api/portals/${portal._id}`, { staging: true })).data
     assert.equal(patched.staging, true)
   })

--- a/tests/features/portals/portals.api.spec.ts
+++ b/tests/features/portals/portals.api.spec.ts
@@ -4,6 +4,8 @@ import 'dotenv/config'
 import { clean, axiosAuth } from '../../support/axios.ts'
 
 const user1 = await axiosAuth('test_admin@test.com')
+const orgAdmin = await axiosAuth({ email: 'test_admin@test.com', org: 'test_org1' })
+const deptAdmin = await axiosAuth({ email: 'test_admin_dep@test.com', org: 'test_org1' })
 
 test.describe('portals management', () => {
   test.beforeEach(clean)
@@ -15,5 +17,28 @@ test.describe('portals management', () => {
     assert.equal(portal.config.authentication, 'optional')
     assert.equal(portal.config.theme.colors.primary, '#1976D2')
     assert.deepEqual(portal.config, portal.draftConfig)
+  })
+
+  test('org-root admin can set sharedWithDepartments on an org-root portal', async () => {
+    const portal = (await orgAdmin.post('/api/portals', { config: { title: 'P', menu: { children: [] } } })).data
+    const patched = (await orgAdmin.patch(`/api/portals/${portal._id}`, { sharedWithDepartments: ['dep1'] })).data
+    assert.deepEqual(patched.sharedWithDepartments, ['dep1'])
+  })
+
+  test('dept admin cannot set sharedWithDepartments on an org-root portal', async () => {
+    const portal = (await orgAdmin.post('/api/portals', { config: { title: 'P', menu: { children: [] } } })).data
+    await assert.rejects(
+      deptAdmin.patch(`/api/portals/${portal._id}`, { sharedWithDepartments: ['dep1'] }),
+      (err: any) => err.status === 403 || err.status === 401
+    )
+  })
+
+  test('setting sharedWithDepartments on a dept-scoped portal is refused', async () => {
+    const portal = (await deptAdmin.post('/api/portals', { config: { title: 'P', menu: { children: [] } } })).data
+    assert.equal(portal.owner.department, 'dep1')
+    await assert.rejects(
+      deptAdmin.patch(`/api/portals/${portal._id}`, { sharedWithDepartments: ['dep2'] }),
+      (err: any) => err.status === 400
+    )
   })
 })

--- a/tests/features/portals/portals.api.spec.ts
+++ b/tests/features/portals/portals.api.spec.ts
@@ -56,4 +56,39 @@ test.describe('portals management', () => {
       (err: any) => err.status === 400
     )
   })
+
+  test('dept admin lists org-root portal when their department is in contributorDepartments', async () => {
+    const sharedPortal = (await orgAdmin.post('/api/portals', { config: { title: 'Shared', menu: { children: [] } } })).data
+    await orgAdmin.patch(`/api/portals/${sharedPortal._id}`, { contributorDepartments: ['dep1'] })
+    const otherPortal = (await orgAdmin.post('/api/portals', { config: { title: 'Other', menu: { children: [] } } })).data
+    const ownPortal = (await deptAdmin.post('/api/portals', { config: { title: 'Own', menu: { children: [] } } })).data
+
+    const list = (await deptAdmin.get('/api/portals')).data
+    const ids = list.results.map((p: any) => p._id)
+    assert.ok(ids.includes(sharedPortal._id), 'shared org-root portal should be visible')
+    assert.ok(ids.includes(ownPortal._id), 'own dept portal should still be visible')
+    assert.ok(!ids.includes(otherPortal._id), 'unrelated org-root portal should not be visible')
+  })
+
+  test('dept admin does not list org-root portal sharing a different department', async () => {
+    const sharedPortal = (await orgAdmin.post('/api/portals', { config: { title: 'Shared', menu: { children: [] } } })).data
+    await orgAdmin.patch(`/api/portals/${sharedPortal._id}`, { contributorDepartments: ['dep2'] })
+
+    const list = (await deptAdmin.get('/api/portals')).data
+    const ids = list.results.map((p: any) => p._id)
+    assert.ok(!ids.includes(sharedPortal._id), 'dep1 admin must not see a portal shared only with dep2')
+  })
+
+  test('org-root admin listing is unaffected by contributorDepartments', async () => {
+    const sharedPortal = (await orgAdmin.post('/api/portals', { config: { title: 'Shared', menu: { children: [] } } })).data
+    await orgAdmin.patch(`/api/portals/${sharedPortal._id}`, { contributorDepartments: ['dep1'] })
+    const plainPortal = (await orgAdmin.post('/api/portals', { config: { title: 'Plain', menu: { children: [] } } })).data
+    const deptPortal = (await deptAdmin.post('/api/portals', { config: { title: 'Dept', menu: { children: [] } } })).data
+
+    const list = (await orgAdmin.get('/api/portals')).data
+    const ids = list.results.map((p: any) => p._id)
+    assert.ok(ids.includes(sharedPortal._id))
+    assert.ok(ids.includes(plainPortal._id))
+    assert.ok(ids.includes(deptPortal._id), 'org-root admin sees dept-scoped portals too')
+  })
 })

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
     <style>@layer vuetify-core, vuetify-components, vuetify-overrides, vuetify-utilities, vuetify-final;</style>
     <link href="{SITE_PATH}/simple-directory/api/sites/{THEME_CSS_HASH}_theme.css" rel="stylesheet">
   </head>

--- a/ui/src/components/page-edit/page-edit-publication.vue
+++ b/ui/src/components/page-edit/page-edit-publication.vue
@@ -114,9 +114,20 @@ const { t } = useI18n()
 const session = useSessionAuthenticated()
 const { patchPage, page, pageUrl } = usePageStore()
 
-type PartialPortal = Pick<Portal, '_id' | 'title' | 'ingress' | 'owner' | 'staging'>
-const portalsFetch = useFetch<{ results: PartialPortal[] }>($apiPath + '/portals', { query: { select: '_id,title,ingress,owner', size: 10000 } })
+type PartialPortal = Pick<Portal, '_id' | 'title' | 'ingress' | 'owner' | 'staging' | 'contributorDepartments'>
+const portalsFetch = useFetch<{ results: PartialPortal[] }>($apiPath + '/portals', { query: { select: '_id,title,ingress,owner,staging,contributorDepartments', size: 10000 } })
 const portals = computed(() => portalsFetch.data.value?.results)
+
+// A user who is contrib/admin in a department listed in contributorDepartments inherits that role on the portal.
+const portalRole = (portal: PartialPortal): string | null => {
+  const role = getAccountRole(session.state, portal.owner)
+  if (role) return role
+  if (!portal.contributorDepartments?.length) return null
+  for (const org of session.state.user.organizations) {
+    if (org.id === portal.owner.id && org.department && portal.contributorDepartments.includes(org.department)) return org.role
+  }
+  return null
+}
 
 // Fetch all standard pages (home, contact, accessibility,...) to detect conflicts
 const standardPagesFetch = useFetch<{ results: Pick<Page, '_id' | 'type' | 'portals' | 'config' | 'title'>[] }>($apiPath + '/pages', {
@@ -147,7 +158,7 @@ const isPublished = (portal: PartialPortal) => {
 }
 
 const canPublish = (portal: PartialPortal) => {
-  const role = getAccountRole(session.state, portal.owner)
+  const role = portalRole(portal)
   if (role === 'contrib' && portal.staging) return true
   return role === 'admin'
 }
@@ -160,7 +171,7 @@ const canUnpublish = (portal: PartialPortal) => {
 }
 
 const canRequestPublication = (portal: PartialPortal) => {
-  const role = getAccountRole(session.state, portal.owner)
+  const role = portalRole(portal)
   return role === 'contrib' || role === 'admin'
 }
 

--- a/ui/src/components/portal/portal-actions.vue
+++ b/ui/src/components/portal/portal-actions.vue
@@ -145,6 +145,66 @@
     </v-card>
   </v-menu>
 
+  <!-- Manage shared departments -->
+  <v-menu
+    v-if="hasDepartments && !portal.owner.department && (session.state.accountRole === 'admin' || session.state.user.adminMode)"
+    v-model="showSharedDeptsMenu"
+    :close-on-content-click="false"
+    max-width="500"
+  >
+    <template #activator="{ props }">
+      <v-list-item
+        v-bind="props"
+        rounded
+      >
+        <template #prepend>
+          <v-icon
+            color="primary"
+            :icon="mdiAccountGroup"
+          />
+        </template>
+        {{ t('manageSharedDepartments') }}
+      </v-list-item>
+    </template>
+    <v-card
+      rounded="lg"
+      variant="elevated"
+      :title="t('manageSharedDepartments')"
+      :loading="updateSharedDepartments.loading.value ? 'primary' : undefined"
+    >
+      <v-card-text>
+        <p class="mb-2">
+          {{ t('sharedDepartmentsHelp') }}
+        </p>
+        <v-combobox
+          v-model="editedSharedDepartments"
+          :label="t('sharedDepartments')"
+          multiple
+          chips
+          closable-chips
+          hide-details="auto"
+        />
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn
+          :disabled="updateSharedDepartments.loading.value"
+          @click="showSharedDeptsMenu = false"
+        >
+          {{ t('cancel') }}
+        </v-btn>
+        <v-btn
+          color="primary"
+          variant="flat"
+          :loading="updateSharedDepartments.loading.value"
+          @click="updateSharedDepartments.execute()"
+        >
+          {{ t('confirm') }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-menu>
+
   <!-- Delete portal -->
   <v-menu
     v-model="showDeleteMenu"
@@ -316,7 +376,7 @@
 </template>
 
 <script setup lang="ts">
-import { mdiDelete, mdiFileReplace, mdiFileExport, mdiFileCancel, mdiOpenInNew, mdiShieldLinkVariant, mdiAccount, mdiClipboardTextClock, mdiShieldStar, mdiViewDashboardEdit } from '@mdi/js'
+import { mdiDelete, mdiFileReplace, mdiFileExport, mdiFileCancel, mdiOpenInNew, mdiShieldLinkVariant, mdiAccount, mdiAccountGroup, mdiClipboardTextClock, mdiShieldStar, mdiViewDashboardEdit } from '@mdi/js'
 import ownerPick from '@data-fair/lib-vuetify/owner-pick.vue'
 import { Portal } from '#api/types/portal/index.ts'
 
@@ -327,6 +387,8 @@ const hasDepartments = useHasDepartments()
 const showChangeOwnerMenu = ref(false)
 const showDeleteMenu = ref(false)
 const showWhiteLabelMenu = ref(false)
+const showSharedDeptsMenu = ref(false)
+const editedSharedDepartments = ref<string[]>([])
 
 const ownersReady = ref(false)
 const newOwner = ref<Record<string, string> | null>(null)
@@ -383,6 +445,22 @@ const updateAdminConfig = useAsyncAction(async (key: string, value: boolean) => 
   error: t('errorUpdatingAdminConfig'),
 })
 
+watch(() => showSharedDeptsMenu.value, (open) => {
+  if (open) editedSharedDepartments.value = [...(portal.sharedWithDepartments || [])]
+})
+
+const updateSharedDepartments = useAsyncAction(async () => {
+  await $fetch(`/portals/${portal._id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ sharedWithDepartments: editedSharedDepartments.value })
+  })
+  showSharedDeptsMenu.value = false
+  emit('refresh-portal')
+}, {
+  success: t('sharedDepartmentsUpdated'),
+  error: t('errorUpdatingSharedDepartments'),
+})
+
 </script>
 
 <i18n lang="yaml">
@@ -406,7 +484,12 @@ const updateAdminConfig = useAsyncAction(async (key: string, value: boolean) => 
     errorDeletingPortal: Error while deleting the portal
     errorUpdatingAdminConfig: Error while updating admin configuration
     events: Events
+    errorUpdatingSharedDepartments: Error while updating shared departments
     manageDomainExposure: Manage domain exposure
+    manageSharedDepartments: Manage shared departments
+    sharedDepartments: Shared departments
+    sharedDepartmentsHelp: Add the id of every department of your organisation whose admins should be allowed to publish on this portal. Type the id and press Enter.
+    sharedDepartmentsUpdated: Shared departments updated!
     no: No
     ownerChanged: Owner changed!
     portalDeleted: Portal deleted!
@@ -438,7 +521,12 @@ const updateAdminConfig = useAsyncAction(async (key: string, value: boolean) => 
     errorDeletingPortal: Erreur lors de la suppression du portail
     errorUpdatingAdminConfig: Erreur lors de la mise à jour de la configuration administrateur
     events: Traçabilité
+    errorUpdatingSharedDepartments: Erreur lors de la mise à jour des départements partagés
     manageDomainExposure: Exposition du domaine
+    manageSharedDepartments: Gérer les départements partagés
+    sharedDepartments: Départements partagés
+    sharedDepartmentsHelp: Ajoutez l'identifiant de chaque département de votre organisation dont les administrateurs peuvent publier sur ce portail. Tapez l'identifiant puis Entrée.
+    sharedDepartmentsUpdated: Départements partagés mis à jour !
     no: Non
     ownerChanged: Propriétaire changé !
     portalDeleted: Portail supprimé !

--- a/ui/src/components/portal/portal-actions.vue
+++ b/ui/src/components/portal/portal-actions.vue
@@ -145,66 +145,6 @@
     </v-card>
   </v-menu>
 
-  <!-- Manage shared departments -->
-  <v-menu
-    v-if="hasDepartments && !portal.owner.department && (session.state.accountRole === 'admin' || session.state.user.adminMode)"
-    v-model="showSharedDeptsMenu"
-    :close-on-content-click="false"
-    max-width="500"
-  >
-    <template #activator="{ props }">
-      <v-list-item
-        v-bind="props"
-        rounded
-      >
-        <template #prepend>
-          <v-icon
-            color="primary"
-            :icon="mdiAccountGroup"
-          />
-        </template>
-        {{ t('manageSharedDepartments') }}
-      </v-list-item>
-    </template>
-    <v-card
-      rounded="lg"
-      variant="elevated"
-      :title="t('manageSharedDepartments')"
-      :loading="updateSharedDepartments.loading.value ? 'primary' : undefined"
-    >
-      <v-card-text>
-        <p class="mb-2">
-          {{ t('sharedDepartmentsHelp') }}
-        </p>
-        <v-combobox
-          v-model="editedSharedDepartments"
-          :label="t('sharedDepartments')"
-          multiple
-          chips
-          closable-chips
-          hide-details="auto"
-        />
-      </v-card-text>
-      <v-card-actions>
-        <v-spacer />
-        <v-btn
-          :disabled="updateSharedDepartments.loading.value"
-          @click="showSharedDeptsMenu = false"
-        >
-          {{ t('cancel') }}
-        </v-btn>
-        <v-btn
-          color="primary"
-          variant="flat"
-          :loading="updateSharedDepartments.loading.value"
-          @click="updateSharedDepartments.execute()"
-        >
-          {{ t('confirm') }}
-        </v-btn>
-      </v-card-actions>
-    </v-card>
-  </v-menu>
-
   <!-- Delete portal -->
   <v-menu
     v-model="showDeleteMenu"
@@ -376,7 +316,7 @@
 </template>
 
 <script setup lang="ts">
-import { mdiDelete, mdiFileReplace, mdiFileExport, mdiFileCancel, mdiOpenInNew, mdiShieldLinkVariant, mdiAccount, mdiAccountGroup, mdiClipboardTextClock, mdiShieldStar, mdiViewDashboardEdit } from '@mdi/js'
+import { mdiDelete, mdiFileReplace, mdiFileExport, mdiFileCancel, mdiOpenInNew, mdiShieldLinkVariant, mdiAccount, mdiClipboardTextClock, mdiShieldStar, mdiViewDashboardEdit } from '@mdi/js'
 import ownerPick from '@data-fair/lib-vuetify/owner-pick.vue'
 import { Portal } from '#api/types/portal/index.ts'
 
@@ -387,8 +327,6 @@ const hasDepartments = useHasDepartments()
 const showChangeOwnerMenu = ref(false)
 const showDeleteMenu = ref(false)
 const showWhiteLabelMenu = ref(false)
-const showSharedDeptsMenu = ref(false)
-const editedSharedDepartments = ref<string[]>([])
 
 const ownersReady = ref(false)
 const newOwner = ref<Record<string, string> | null>(null)
@@ -445,22 +383,6 @@ const updateAdminConfig = useAsyncAction(async (key: string, value: boolean) => 
   error: t('errorUpdatingAdminConfig'),
 })
 
-watch(() => showSharedDeptsMenu.value, (open) => {
-  if (open) editedSharedDepartments.value = [...(portal.sharedWithDepartments || [])]
-})
-
-const updateSharedDepartments = useAsyncAction(async () => {
-  await $fetch(`/portals/${portal._id}`, {
-    method: 'PATCH',
-    body: JSON.stringify({ sharedWithDepartments: editedSharedDepartments.value })
-  })
-  showSharedDeptsMenu.value = false
-  emit('refresh-portal')
-}, {
-  success: t('sharedDepartmentsUpdated'),
-  error: t('errorUpdatingSharedDepartments'),
-})
-
 </script>
 
 <i18n lang="yaml">
@@ -484,12 +406,7 @@ const updateSharedDepartments = useAsyncAction(async () => {
     errorDeletingPortal: Error while deleting the portal
     errorUpdatingAdminConfig: Error while updating admin configuration
     events: Events
-    errorUpdatingSharedDepartments: Error while updating shared departments
     manageDomainExposure: Manage domain exposure
-    manageSharedDepartments: Manage shared departments
-    sharedDepartments: Shared departments
-    sharedDepartmentsHelp: Add the id of every department of your organisation whose admins should be allowed to publish on this portal. Type the id and press Enter.
-    sharedDepartmentsUpdated: Shared departments updated!
     no: No
     ownerChanged: Owner changed!
     portalDeleted: Portal deleted!
@@ -521,12 +438,7 @@ const updateSharedDepartments = useAsyncAction(async () => {
     errorDeletingPortal: Erreur lors de la suppression du portail
     errorUpdatingAdminConfig: Erreur lors de la mise à jour de la configuration administrateur
     events: Traçabilité
-    errorUpdatingSharedDepartments: Erreur lors de la mise à jour des départements partagés
     manageDomainExposure: Exposition du domaine
-    manageSharedDepartments: Gérer les départements partagés
-    sharedDepartments: Départements partagés
-    sharedDepartmentsHelp: Ajoutez l'identifiant de chaque département de votre organisation dont les administrateurs peuvent publier sur ce portail. Tapez l'identifiant puis Entrée.
-    sharedDepartmentsUpdated: Départements partagés mis à jour !
     no: Non
     ownerChanged: Propriétaire changé !
     portalDeleted: Portail supprimé !

--- a/ui/src/components/portal/portal-actions.vue
+++ b/ui/src/components/portal/portal-actions.vue
@@ -78,6 +78,26 @@
     </v-list-item>
   </custom-router-link>
 
+  <!-- Manage contributions -->
+  <v-list-item
+    v-if="canEditContributions"
+    @click="showContributionsDialog = true"
+  >
+    <template #prepend>
+      <v-icon
+        color="primary"
+        :icon="mdiAccountGroup"
+      />
+    </template>
+    {{ t('manageContributions') }}
+  </v-list-item>
+  <portal-contributions-dialog
+    v-if="canEditContributions"
+    v-model="showContributionsDialog"
+    :portal="portal"
+    @refresh-portal="emit('refresh-portal')"
+  />
+
   <!-- Change owner -->
   <v-menu
     v-if="hasDepartments && (session.state.accountRole === 'admin' || session.state.user.adminMode)"
@@ -316,7 +336,7 @@
 </template>
 
 <script setup lang="ts">
-import { mdiDelete, mdiFileReplace, mdiFileExport, mdiFileCancel, mdiOpenInNew, mdiShieldLinkVariant, mdiAccount, mdiClipboardTextClock, mdiShieldStar, mdiViewDashboardEdit } from '@mdi/js'
+import { mdiDelete, mdiFileReplace, mdiFileExport, mdiFileCancel, mdiOpenInNew, mdiShieldLinkVariant, mdiAccount, mdiAccountGroup, mdiClipboardTextClock, mdiShieldStar, mdiViewDashboardEdit } from '@mdi/js'
 import ownerPick from '@data-fair/lib-vuetify/owner-pick.vue'
 import { Portal } from '#api/types/portal/index.ts'
 
@@ -327,6 +347,9 @@ const hasDepartments = useHasDepartments()
 const showChangeOwnerMenu = ref(false)
 const showDeleteMenu = ref(false)
 const showWhiteLabelMenu = ref(false)
+const showContributionsDialog = ref(false)
+
+const canEditContributions = computed(() => session.state.accountRole === 'admin' || session.state.user.adminMode)
 
 const ownersReady = ref(false)
 const newOwner = ref<Record<string, string> | null>(null)
@@ -406,6 +429,7 @@ const updateAdminConfig = useAsyncAction(async (key: string, value: boolean) => 
     errorDeletingPortal: Error while deleting the portal
     errorUpdatingAdminConfig: Error while updating admin configuration
     events: Events
+    manageContributions: Contribution management
     manageDomainExposure: Manage domain exposure
     no: No
     ownerChanged: Owner changed!
@@ -438,6 +462,7 @@ const updateAdminConfig = useAsyncAction(async (key: string, value: boolean) => 
     errorDeletingPortal: Erreur lors de la suppression du portail
     errorUpdatingAdminConfig: Erreur lors de la mise à jour de la configuration administrateur
     events: Traçabilité
+    manageContributions: Gestion des contributions
     manageDomainExposure: Exposition du domaine
     no: Non
     ownerChanged: Propriétaire changé !

--- a/ui/src/components/portal/portal-contributions-dialog.vue
+++ b/ui/src/components/portal/portal-contributions-dialog.vue
@@ -1,0 +1,126 @@
+<template>
+  <v-dialog
+    v-model="show"
+    max-width="600"
+    :persistent="save.loading.value"
+  >
+    <v-card
+      :title="t('contributionManagementTitle')"
+      :subtitle="t('contributionManagementSubtitle')"
+      :loading="save.loading.value ? 'primary' : undefined"
+    >
+      <v-card-text>
+        <v-checkbox
+          v-model="staging"
+          :label="t('stagingLabel')"
+          :hint="t('stagingHint')"
+          persistent-hint
+          color="primary"
+          density="comfortable"
+        />
+        <v-select
+          v-if="departments.length"
+          v-model="contributorDepartments"
+          :items="departments"
+          item-title="name"
+          item-value="id"
+          class="mt-4"
+          :label="t('contributorDepartmentsLabel')"
+          :hint="t('contributorDepartmentsHint')"
+          persistent-hint
+          multiple
+          chips
+          closable-chips
+        />
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn
+          :disabled="save.loading.value"
+          @click="show = false"
+        >
+          {{ t('cancel') }}
+        </v-btn>
+        <v-btn
+          color="primary"
+          variant="flat"
+          :loading="save.loading.value"
+          @click="save.execute()"
+        >
+          {{ t('save') }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { Portal } from '#api/types/portal/index.ts'
+
+const { t } = useI18n()
+
+const show = defineModel<boolean>({ default: false })
+const props = defineProps<{ portal: Portal }>()
+
+const departmentsFetch = useFetch<{ departments?: { id: string, name: string }[] }>(
+  () => props.portal.owner.type === 'organization' && !props.portal.owner.department
+    ? `${$sitePath}/simple-directory/api/organizations/${props.portal.owner.id}`
+    : null,
+  { notifError: false }
+)
+const departments = computed(() => departmentsFetch.data.value?.departments ?? [])
+const emit = defineEmits<{ (e: 'refresh-portal'): void }>()
+
+const staging = ref(!!props.portal.staging)
+const contributorDepartments = ref<string[]>(props.portal.contributorDepartments ?? [])
+
+watch(show, (visible) => {
+  if (visible) {
+    staging.value = !!props.portal.staging
+    contributorDepartments.value = props.portal.contributorDepartments ?? []
+  }
+})
+
+const save = useAsyncAction(
+  async () => {
+    await $fetch(`/portals/${props.portal._id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({
+        staging: staging.value,
+        contributorDepartments: contributorDepartments.value
+      })
+    })
+    emit('refresh-portal')
+    show.value = false
+  },
+  {
+    success: t('contributionsUpdated'),
+    error: t('errorUpdatingContributions'),
+  }
+)
+</script>
+
+<i18n lang="yaml">
+  en:
+    contributionManagementTitle: Contribution management
+    contributionManagementSubtitle: Who can publish datasets and applications on this portal
+    stagingLabel: Staging portal
+    stagingHint: If enabled, any organisation contributor may publish directly on this portal without admin approval.
+    contributorDepartmentsLabel: Contributor departments
+    contributorDepartmentsHint: Admins of the selected departments may publish on this portal as if it were owned by their department.
+    cancel: Cancel
+    save: Save
+    contributionsUpdated: Contribution settings updated
+    errorUpdatingContributions: Error while updating contribution settings
+  fr:
+    contributionManagementTitle: Gestion des contributions
+    contributionManagementSubtitle: Qui peut publier des jeux de données et des applications sur ce portail
+    stagingLabel: Portail de pré-production
+    stagingHint: Si activé, tout contributeur de l'organisation peut publier directement sur ce portail sans validation par un administrateur.
+    contributorDepartmentsLabel: Départements contributeurs
+    contributorDepartmentsHint: Les administrateurs des départements sélectionnés pourront publier sur ce portail comme s'ils en étaient propriétaires.
+    cancel: Annuler
+    save: Enregistrer
+    contributionsUpdated: Paramètres de contribution mis à jour
+    errorUpdatingContributions: Erreur lors de la mise à jour des paramètres de contribution
+</i18n>

--- a/ui/src/components/portal/portal-contributions-dialog.vue
+++ b/ui/src/components/portal/portal-contributions-dialog.vue
@@ -103,22 +103,22 @@ const save = useAsyncAction(
 <i18n lang="yaml">
   en:
     contributionManagementTitle: Contribution management
-    contributionManagementSubtitle: Who can publish datasets and applications on this portal
+    contributionManagementSubtitle: Define who can publish content on this portal
     stagingLabel: Staging portal
-    stagingHint: If enabled, any organisation contributor may publish directly on this portal without admin approval.
+    stagingHint: When enabled, the contributor role is enough to publish on the portal. When disabled, the admin role is required.
     contributorDepartmentsLabel: Contributor departments
-    contributorDepartmentsHint: Admins of the selected departments may publish on this portal as if it were owned by their department.
+    contributorDepartmentsHint: Members of the selected departments can contribute to this portal with the role they hold in their department.
     cancel: Cancel
     save: Save
     contributionsUpdated: Contribution settings updated
     errorUpdatingContributions: Error while updating contribution settings
   fr:
     contributionManagementTitle: Gestion des contributions
-    contributionManagementSubtitle: Qui peut publier des jeux de données et des applications sur ce portail
+    contributionManagementSubtitle: Définir qui peut publier du contenu sur ce portail
     stagingLabel: Portail de pré-production
-    stagingHint: Si activé, tout contributeur de l'organisation peut publier directement sur ce portail sans validation par un administrateur.
+    stagingHint: Si activé, le rôle de contributeur suffit pour publier sur le portail. Sinon, le rôle d'administrateur est requis.
     contributorDepartmentsLabel: Départements contributeurs
-    contributorDepartmentsHint: Les administrateurs des départements sélectionnés pourront publier sur ce portail comme s'ils en étaient propriétaires.
+    contributorDepartmentsHint: Les membres des départements sélectionnés peuvent contribuer à ce portail avec le rôle qu'ils ont dans leur département.
     cancel: Annuler
     save: Enregistrer
     contributionsUpdated: Paramètres de contribution mis à jour

--- a/ui/src/pages/portals/[id]/index.vue
+++ b/ui/src/pages/portals/[id]/index.vue
@@ -1,9 +1,6 @@
 <template>
-  <v-container
-    v-if="portal"
-    data-iframe-height
-  >
-    <theme-loader />
+  <v-container data-iframe-height>
+    <theme-loader v-if="editConfig" />
 
     <v-defaults-provider
       :defaults="{
@@ -15,36 +12,10 @@
         }
       }"
     >
-      <v-form v-model="formValid">
-        <v-card
-          v-if="canEditContributions"
-          class="mb-4"
-          variant="outlined"
-          :title="t('contributionManagementTitle')"
-          :subtitle="t('contributionManagementSubtitle')"
-        >
-          <v-card-text>
-            <v-checkbox
-              v-model="portal.staging"
-              :label="t('stagingLabel')"
-              :hint="t('stagingHint')"
-              persistent-hint
-              color="primary"
-              density="comfortable"
-            />
-            <v-combobox
-              v-if="hasDepartments && !portal.owner.department"
-              v-model="portal.contributorDepartments"
-              class="mt-4"
-              :label="t('contributorDepartmentsLabel')"
-              :hint="t('contributorDepartmentsHint')"
-              persistent-hint
-              multiple
-              chips
-              closable-chips
-            />
-          </v-card-text>
-        </v-card>
+      <v-form
+        v-if="editConfig"
+        v-model="formValid"
+      >
         <div class="d-flex justify-end mb-1">
           <df-agent-chat-action
             action-id="configure-portal"
@@ -54,12 +25,13 @@
         </div>
         <vjsf-portal-config
           v-if="vjsfOptions"
-          v-model="portal.draftConfig"
+          v-model="editConfig"
           :locale="locale"
           :options="vjsfOptions"
           :data-title="t('portalConfig')"
           prefix-name="portalConfig_"
           :sub-agent="true"
+          @update:model-value="saveDraft.execute()"
         >
           <template #colors-preview="context">
             <colors-preview
@@ -187,35 +159,19 @@
       </v-form>
     </v-defaults-provider>
 
-    <navigation-right>
-      <v-list
-        v-if="portalEditFetch.hasDiff.value"
-        bg-color="background"
-      >
-        <v-list-item>
-          <v-btn
-            width="100%"
-            color="accent"
-            :disabled="!formValid"
-            :loading="portalEditFetch.save.loading.value"
-            @click="portalEditFetch.save.execute()"
-          >
-            {{ t('save') }}
-          </v-btn>
-        </v-list-item>
-      </v-list>
+    <navigation-right v-if="portalFetch.data.value">
       <portal-actions
         :has-draft-diff="hasDraftDiff"
-        :is-saving-draft="portalEditFetch.save.loading.value"
-        :portal="portal"
-        @refresh-portal="portalEditFetch.fetch.refresh()"
+        :is-saving-draft="saveDraft.loading.value"
+        :portal="portalFetch.data.value"
+        @refresh-portal="portalFetch.refresh()"
       />
     </navigation-right>
   </v-container>
 </template>
 
 <script lang="ts" setup>
-import type { Portal } from '#api/types/portal'
+import type { Portal, PortalConfig } from '#api/types/portal'
 import type { Page, Group } from '#api/types/page'
 import type { Options as VjsfOptions } from '@koumoul/vjsf'
 
@@ -227,54 +183,56 @@ import equal from 'fast-deep-equal'
 
 const { t, locale } = useI18n()
 const session = useSessionAuthenticated()
-const hasDepartments = useHasDepartments()
 const route = useRoute<'/portals/[id]/'>()
 
-const portalEditFetch = useEditFetch<Portal>(`${$apiPath}/portals/${route.params.id}`, {
-  patch: true,
-  saveOptions: { success: t('saved'), error: t('errorSaving') }
-})
-useLeaveGuard(portalEditFetch.hasDiff, { locale })
-
-const portal = portalEditFetch.data
+const portalFetch = useFetch<Portal>($apiPath + '/portals/' + route.params.id)
+const editConfig = ref<PortalConfig>()
 const formValid = ref(false)
 const { portalConfig } = providePortalStore()
 
-const canEditContributions = computed(() => session.state.accountRole === 'admin' || session.state.user.adminMode)
-
-const hasDraftDiff = computed(() => {
-  const server = portalEditFetch.serverData.value
-  return !!server && !equal(server.draftConfig, server.config)
-})
-
-// Feed the preview store from the live edited draftConfig
-watch(() => portal.value?.draftConfig, (draftConfig) => {
-  if (draftConfig) portalConfig.value = draftConfig
-}, { deep: true, immediate: true })
-
-// When switching assisted <-> manual, rebuild / carry over the theme palette
-watch(() => portal.value?.draftConfig?.theme?.assistedMode, (newVal, oldVal) => {
-  const theme = portal.value?.draftConfig?.theme
-  if (!theme) return
-  if (oldVal === true && newVal === false) {
-    const filled = fillTheme({ ...theme, assistedMode: true }, defaultTheme)
-    theme.colors = filled.colors
-    theme.darkColors = filled.darkColors
-    theme.hcColors = filled.hcColors
-    theme.hcDarkColors = filled.hcDarkColors
+// Initialize editConfig and portalStore when init portal config is fetched
+watch(portalFetch.data, () => {
+  if (!portalFetch.data.value) return
+  if (!equal(editConfig.value, portalFetch.data.value.draftConfig)) {
+    editConfig.value = portalFetch.data.value.draftConfig
   }
-  if (oldVal === false && newVal === true) {
-    theme.assistedModeColors = {
-      primary: theme.colors?.primary ?? defaultTheme.colors.primary,
-      secondary: theme.colors?.secondary ?? defaultTheme.colors.secondary,
-      accent: theme.colors?.accent ?? defaultTheme.colors.accent
+  if (editConfig.value) portalConfig.value = editConfig.value
+})
+// Synchronize editConfig changes back to portalConfig
+watch(editConfig, (newConfig) => {
+  if (newConfig) portalConfig.value = newConfig
+})
+// When switching from assisted to manual mode, expand assisted colors into the full palette
+// When switching from manual to assisted mode, carry over primary/secondary/accent into assistedModeColors
+watch(() => editConfig.value?.theme?.assistedMode, (newVal, oldVal) => {
+  if (oldVal === true && newVal === false && editConfig.value?.theme) {
+    const filled = fillTheme({ ...editConfig.value.theme, assistedMode: true }, defaultTheme)
+    editConfig.value.theme.colors = filled.colors
+    editConfig.value.theme.darkColors = filled.darkColors
+    editConfig.value.theme.hcColors = filled.hcColors
+    editConfig.value.theme.hcDarkColors = filled.hcDarkColors
+  }
+  if (oldVal === false && newVal === true && editConfig.value?.theme) {
+    editConfig.value.theme.assistedModeColors = {
+      primary: editConfig.value.theme.colors?.primary ?? defaultTheme.colors.primary,
+      secondary: editConfig.value.theme.colors?.secondary ?? defaultTheme.colors.secondary,
+      accent: editConfig.value.theme.colors?.accent ?? defaultTheme.colors.accent
     }
   }
 })
 
-watch(portal, (p) => {
-  if (!p) return
-  setBreadcrumbs([{ text: t('portals'), to: '/portals' }, { text: p.config.title }])
+const saveDraft = useAsyncAction(async () => {
+  if (!formValid.value) return
+  await $fetch(`/portals/${route.params.id}`, { method: 'PATCH', body: { draftConfig: editConfig.value } })
+})
+
+const hasDraftDiff = computed(() => {
+  return !equal(editConfig.value, portalFetch.data.value?.config)
+})
+
+watch(portalFetch.data, (portal) => {
+  if (!portal) return
+  setBreadcrumbs([{ text: t('portals'), to: '/portals' }, { text: portal.config.title }])
 })
 
 const pagesFetch = useFetch<{ results: Page[] }>($apiPath + '/pages', {
@@ -330,8 +288,8 @@ const configureContext = computed(() => {
     'Use the subagent tool portalConfig_form to help the user configure the current portal.',
     'Start the session by asking the user what they want to achieve.',
   ]
-  if (portal.value?.draftConfig?.title) lines.push(`The portal title is "${portal.value.draftConfig.title}".`)
-  if (portal.value?.draftConfig?.description) lines.push(`Description: ${portal.value.draftConfig.description}`)
+  if (editConfig.value?.title) lines.push(`The portal title is "${editConfig.value.title}".`)
+  if (editConfig.value?.description) lines.push(`Description: ${editConfig.value.description}`)
   return lines.join(' ')
 })
 
@@ -366,15 +324,6 @@ const vjsfOptions = computed<VjsfOptions | null>(() => ({
     portals: Portals
     portalConfig: Portal configuration
     configurePrompt: Help me configure this portal
-    contributionManagementTitle: Contribution management
-    contributionManagementSubtitle: Who can publish datasets and applications on this portal
-    stagingLabel: Staging portal
-    stagingHint: If enabled, any organisation contributor may publish directly on this portal without admin approval.
-    contributorDepartmentsLabel: Contributor departments
-    contributorDepartmentsHint: Admins of the listed departments may publish on this portal as if it were owned by their department. Type a department id and press Enter.
-    save: Save
-    saved: Changes saved
-    errorSaving: Error while saving
   fr:
     appBarPreview: Entête & Barre de navigation
     breadcrumbs: Fil d'Ariane
@@ -383,13 +332,4 @@ const vjsfOptions = computed<VjsfOptions | null>(() => ({
     portals: Portails
     portalConfig: Configuration du portail
     configurePrompt: Aide-moi à configurer ce portail
-    contributionManagementTitle: Gestion des contributions
-    contributionManagementSubtitle: Qui peut publier des jeux de données et des applications sur ce portail
-    stagingLabel: Portail de pré-production
-    stagingHint: Si activé, tout contributeur de l'organisation peut publier directement sur ce portail sans validation par un administrateur.
-    contributorDepartmentsLabel: Départements contributeurs
-    contributorDepartmentsHint: Les administrateurs des départements listés pourront publier sur ce portail comme s'ils en étaient propriétaires. Tapez un identifiant de département puis Entrée.
-    save: Enregistrer
-    saved: Modifications enregistrées
-    errorSaving: Erreur lors de l'enregistrement
 </i18n>

--- a/ui/src/pages/portals/[id]/index.vue
+++ b/ui/src/pages/portals/[id]/index.vue
@@ -1,6 +1,9 @@
 <template>
-  <v-container data-iframe-height>
-    <theme-loader v-if="editConfig" />
+  <v-container
+    v-if="portal"
+    data-iframe-height
+  >
+    <theme-loader />
 
     <v-defaults-provider
       :defaults="{
@@ -12,10 +15,36 @@
         }
       }"
     >
-      <v-form
-        v-if="editConfig"
-        v-model="formValid"
-      >
+      <v-form v-model="formValid">
+        <v-card
+          v-if="canEditContributions"
+          class="mb-4"
+          variant="outlined"
+          :title="t('contributionManagementTitle')"
+          :subtitle="t('contributionManagementSubtitle')"
+        >
+          <v-card-text>
+            <v-checkbox
+              v-model="portal.staging"
+              :label="t('stagingLabel')"
+              :hint="t('stagingHint')"
+              persistent-hint
+              color="primary"
+              density="comfortable"
+            />
+            <v-combobox
+              v-if="hasDepartments && !portal.owner.department"
+              v-model="portal.contributorDepartments"
+              class="mt-4"
+              :label="t('contributorDepartmentsLabel')"
+              :hint="t('contributorDepartmentsHint')"
+              persistent-hint
+              multiple
+              chips
+              closable-chips
+            />
+          </v-card-text>
+        </v-card>
         <div class="d-flex justify-end mb-1">
           <df-agent-chat-action
             action-id="configure-portal"
@@ -25,13 +54,12 @@
         </div>
         <vjsf-portal-config
           v-if="vjsfOptions"
-          v-model="editConfig"
+          v-model="portal.draftConfig"
           :locale="locale"
           :options="vjsfOptions"
           :data-title="t('portalConfig')"
           prefix-name="portalConfig_"
           :sub-agent="true"
-          @update:model-value="saveDraft.execute()"
         >
           <template #colors-preview="context">
             <colors-preview
@@ -159,19 +187,35 @@
       </v-form>
     </v-defaults-provider>
 
-    <navigation-right v-if="portalFetch.data.value">
+    <navigation-right>
+      <v-list
+        v-if="portalEditFetch.hasDiff.value"
+        bg-color="background"
+      >
+        <v-list-item>
+          <v-btn
+            width="100%"
+            color="accent"
+            :disabled="!formValid"
+            :loading="portalEditFetch.save.loading.value"
+            @click="portalEditFetch.save.execute()"
+          >
+            {{ t('save') }}
+          </v-btn>
+        </v-list-item>
+      </v-list>
       <portal-actions
         :has-draft-diff="hasDraftDiff"
-        :is-saving-draft="saveDraft.loading.value"
-        :portal="portalFetch.data.value"
-        @refresh-portal="portalFetch.refresh()"
+        :is-saving-draft="portalEditFetch.save.loading.value"
+        :portal="portal"
+        @refresh-portal="portalEditFetch.fetch.refresh()"
       />
     </navigation-right>
   </v-container>
 </template>
 
 <script lang="ts" setup>
-import type { Portal, PortalConfig } from '#api/types/portal'
+import type { Portal } from '#api/types/portal'
 import type { Page, Group } from '#api/types/page'
 import type { Options as VjsfOptions } from '@koumoul/vjsf'
 
@@ -183,56 +227,54 @@ import equal from 'fast-deep-equal'
 
 const { t, locale } = useI18n()
 const session = useSessionAuthenticated()
+const hasDepartments = useHasDepartments()
 const route = useRoute<'/portals/[id]/'>()
 
-const portalFetch = useFetch<Portal>($apiPath + '/portals/' + route.params.id)
-const editConfig = ref<PortalConfig>()
+const portalEditFetch = useEditFetch<Portal>(`${$apiPath}/portals/${route.params.id}`, {
+  patch: true,
+  saveOptions: { success: t('saved'), error: t('errorSaving') }
+})
+useLeaveGuard(portalEditFetch.hasDiff, { locale })
+
+const portal = portalEditFetch.data
 const formValid = ref(false)
 const { portalConfig } = providePortalStore()
 
-// Initialize editConfig and portalStore when init portal config is fetched
-watch(portalFetch.data, () => {
-  if (!portalFetch.data.value) return
-  if (!equal(editConfig.value, portalFetch.data.value.draftConfig)) {
-    editConfig.value = portalFetch.data.value.draftConfig
-  }
-  if (editConfig.value) portalConfig.value = editConfig.value
+const canEditContributions = computed(() => session.state.accountRole === 'admin' || session.state.user.adminMode)
+
+const hasDraftDiff = computed(() => {
+  const server = portalEditFetch.serverData.value
+  return !!server && !equal(server.draftConfig, server.config)
 })
-// Synchronize editConfig changes back to portalConfig
-watch(editConfig, (newConfig) => {
-  if (newConfig) portalConfig.value = newConfig
-})
-// When switching from assisted to manual mode, expand assisted colors into the full palette
-// When switching from manual to assisted mode, carry over primary/secondary/accent into assistedModeColors
-watch(() => editConfig.value?.theme?.assistedMode, (newVal, oldVal) => {
-  if (oldVal === true && newVal === false && editConfig.value?.theme) {
-    const filled = fillTheme({ ...editConfig.value.theme, assistedMode: true }, defaultTheme)
-    editConfig.value.theme.colors = filled.colors
-    editConfig.value.theme.darkColors = filled.darkColors
-    editConfig.value.theme.hcColors = filled.hcColors
-    editConfig.value.theme.hcDarkColors = filled.hcDarkColors
+
+// Feed the preview store from the live edited draftConfig
+watch(() => portal.value?.draftConfig, (draftConfig) => {
+  if (draftConfig) portalConfig.value = draftConfig
+}, { deep: true, immediate: true })
+
+// When switching assisted <-> manual, rebuild / carry over the theme palette
+watch(() => portal.value?.draftConfig?.theme?.assistedMode, (newVal, oldVal) => {
+  const theme = portal.value?.draftConfig?.theme
+  if (!theme) return
+  if (oldVal === true && newVal === false) {
+    const filled = fillTheme({ ...theme, assistedMode: true }, defaultTheme)
+    theme.colors = filled.colors
+    theme.darkColors = filled.darkColors
+    theme.hcColors = filled.hcColors
+    theme.hcDarkColors = filled.hcDarkColors
   }
-  if (oldVal === false && newVal === true && editConfig.value?.theme) {
-    editConfig.value.theme.assistedModeColors = {
-      primary: editConfig.value.theme.colors?.primary ?? defaultTheme.colors.primary,
-      secondary: editConfig.value.theme.colors?.secondary ?? defaultTheme.colors.secondary,
-      accent: editConfig.value.theme.colors?.accent ?? defaultTheme.colors.accent
+  if (oldVal === false && newVal === true) {
+    theme.assistedModeColors = {
+      primary: theme.colors?.primary ?? defaultTheme.colors.primary,
+      secondary: theme.colors?.secondary ?? defaultTheme.colors.secondary,
+      accent: theme.colors?.accent ?? defaultTheme.colors.accent
     }
   }
 })
 
-const saveDraft = useAsyncAction(async () => {
-  if (!formValid.value) return
-  await $fetch(`/portals/${route.params.id}`, { method: 'PATCH', body: { draftConfig: editConfig.value } })
-})
-
-const hasDraftDiff = computed(() => {
-  return !equal(editConfig.value, portalFetch.data.value?.config)
-})
-
-watch(portalFetch.data, (portal) => {
-  if (!portal) return
-  setBreadcrumbs([{ text: t('portals'), to: '/portals' }, { text: portal.config.title }])
+watch(portal, (p) => {
+  if (!p) return
+  setBreadcrumbs([{ text: t('portals'), to: '/portals' }, { text: p.config.title }])
 })
 
 const pagesFetch = useFetch<{ results: Page[] }>($apiPath + '/pages', {
@@ -288,8 +330,8 @@ const configureContext = computed(() => {
     'Use the subagent tool portalConfig_form to help the user configure the current portal.',
     'Start the session by asking the user what they want to achieve.',
   ]
-  if (editConfig.value?.title) lines.push(`The portal title is "${editConfig.value.title}".`)
-  if (editConfig.value?.description) lines.push(`Description: ${editConfig.value.description}`)
+  if (portal.value?.draftConfig?.title) lines.push(`The portal title is "${portal.value.draftConfig.title}".`)
+  if (portal.value?.draftConfig?.description) lines.push(`Description: ${portal.value.draftConfig.description}`)
   return lines.join(' ')
 })
 
@@ -324,6 +366,15 @@ const vjsfOptions = computed<VjsfOptions | null>(() => ({
     portals: Portals
     portalConfig: Portal configuration
     configurePrompt: Help me configure this portal
+    contributionManagementTitle: Contribution management
+    contributionManagementSubtitle: Who can publish datasets and applications on this portal
+    stagingLabel: Staging portal
+    stagingHint: If enabled, any organisation contributor may publish directly on this portal without admin approval.
+    contributorDepartmentsLabel: Contributor departments
+    contributorDepartmentsHint: Admins of the listed departments may publish on this portal as if it were owned by their department. Type a department id and press Enter.
+    save: Save
+    saved: Changes saved
+    errorSaving: Error while saving
   fr:
     appBarPreview: Entête & Barre de navigation
     breadcrumbs: Fil d'Ariane
@@ -332,4 +383,13 @@ const vjsfOptions = computed<VjsfOptions | null>(() => ({
     portals: Portails
     portalConfig: Configuration du portail
     configurePrompt: Aide-moi à configurer ce portail
+    contributionManagementTitle: Gestion des contributions
+    contributionManagementSubtitle: Qui peut publier des jeux de données et des applications sur ce portail
+    stagingLabel: Portail de pré-production
+    stagingHint: Si activé, tout contributeur de l'organisation peut publier directement sur ce portail sans validation par un administrateur.
+    contributorDepartmentsLabel: Départements contributeurs
+    contributorDepartmentsHint: Les administrateurs des départements listés pourront publier sur ce portail comme s'ils en étaient propriétaires. Tapez un identifiant de département puis Entrée.
+    save: Enregistrer
+    saved: Modifications enregistrées
+    errorSaving: Erreur lors de l'enregistrement
 </i18n>

--- a/ui/src/pages/portals/index.vue
+++ b/ui/src/pages/portals/index.vue
@@ -73,13 +73,26 @@ const showAll = useBooleanSearchParam('showAll')
 const search = useStringSearchParam('q')
 const { t } = useI18n()
 
+// Restrict to portals actually owned by the session's account: drops portals
+// that are only contribute-shared via contributorDepartments.
+const ownerFilter = computed(() => {
+  const a = session.state.account
+  let o = a.type + ':' + a.id
+  if (a.department) o += ':' + a.department
+  return o
+})
+
 const portalsParams = computed(() => {
   const params: Record<string, any> = {
     size: 10000,
     sort: 'updatedAt:-1',
-    select: '_id,config.title,config.description,config.authentication,ingress.url,owner'
+    select: '_id,config.title,config.description,config.authentication,ingress.url,owner',
+    owner: ownerFilter.value
   }
-  if (showAll.value) params.showAll = true
+  if (showAll.value) {
+    params.showAll = true
+    delete params.owner
+  }
   return params
 })
 

--- a/ui/src/pages/portals/new.vue
+++ b/ui/src/pages/portals/new.vue
@@ -66,12 +66,6 @@
               autofocus
               required
             />
-            <v-checkbox
-              v-model="generalInformations.staging.value"
-              :label="t('form.staging')"
-              density="comfortable"
-              hide-details
-            />
           </v-form>
 
           <!-- Select owner -->
@@ -518,11 +512,6 @@
               :subtitle="generalInformations.owner.value.name"
             />
             <v-list-item
-              v-if="generalInformations.staging.value"
-              :title="t('summary.staging')"
-              :subtitle="t('summary.yes')"
-            />
-            <v-list-item
               :title="t('summary.sourcePortal')"
               :subtitle="selectedPortalLabel"
             />
@@ -579,7 +568,6 @@ const step = ref<'general-information' | 'home' | 'datasets-catalog' | 'applicat
 
 const generalInformations = {
   title: ref<string>(''),
-  staging: ref<boolean>(false),
   owner: ref<Account>(session.state.account)
 }
 const selectedPortal = ref<string | undefined>(undefined)
@@ -719,7 +707,6 @@ const createPortal = useAsyncAction(
       method: 'POST',
       body: {
         owner,
-        staging: generalInformations.staging.value,
         sourcePortalId: selectedPortal.value !== 'blank' ? selectedPortal.value : undefined, // Source page ID to duplicate (optional)
         config: { title: portalTitle, menu: selectedPortal.value !== 'blank' ? undefined : menu } // Init menu only if not duplicating from another portal
       }
@@ -803,7 +790,6 @@ setBreadcrumbs([
     form:
       title: Portal Title
       titleRequired: Portal title is required
-      staging: Staging Portal
       owner: Choose the portal owner
     initFromOtherPortal:
       title: Initialize configuration from an existing portal
@@ -841,8 +827,6 @@ setBreadcrumbs([
     summary:
       title: Portal Title
       owner: Owner
-      staging: Staging
-      yes: "Yes"
       sourcePortal: Source Portal
       homePage: Home Page
       datasetsCatalog: Datasets Catalog
@@ -860,7 +844,6 @@ setBreadcrumbs([
     form:
       title: Titre du portail
       titleRequired: Le titre du portail est obligatoire
-      staging: Portail de pré-production
       owner: Choisir le propriétaire du portail
     initFromOtherPortal:
       title: Initialiser la configuration depuis un portail existant
@@ -898,8 +881,6 @@ setBreadcrumbs([
     summary:
       title: Titre du portail
       owner: Propriétaire
-      staging: Pré-production
-      yes: "Oui"
       sourcePortal: Portail source
       homePage: Page d'accueil
       datasetsCatalog: Catalogue de données


### PR DESCRIPTION
Better implementation of `staging` portals (portals opened to direct contribution by user with role contrib).

Add `contributorDepartments that open publishing permissions to a organization level portal to users from departments.