### PR TITLE
feat(portal): unify datasets/applications sort on modified/updatedAt

### DIFF
--- a/api/types/page-element-datasets/schema.js
+++ b/api/types/page-element-datasets/schema.js
@@ -21,7 +21,7 @@ export default {
           default: 'createdAt:-1',
           oneOf: [
             { const: 'createdAt:-1', title: 'Date de création (du plus récent au plus ancien)' },
-            { const: 'dataUpdatedAt:-1', title: 'Date de mise à jour (du plus récent au plus ancien)' },
+            { const: 'modified:-1', title: 'Date de mise à jour (du plus récent au plus ancien)' },
             { const: 'title:1', title: 'Ordre alphabétique (A à Z)' },
             { const: 'owner.departmentName:1', title: 'Propriétaire' }
           ]

--- a/portal/app/components/catalog-filters.vue
+++ b/portal/app/components/catalog-filters.vue
@@ -377,7 +377,7 @@ const sortItems = computed(() => {
     case 'datasets':
       return [
         { title: t('sort.createdAt'), value: 'createdAt' },
-        { title: t('sort.dataUpdatedAt'), value: 'dataUpdatedAt' },
+        { title: t('sort.modified'), value: 'modified' },
         { title: t('sort.title'), value: 'title' },
         { title: ownerLabel, value: 'owner.departmentName' }
       ]
@@ -426,7 +426,7 @@ const sortItems = computed(() => {
     search: Search
     sort:
       createdAt: Creation date
-      dataUpdatedAt: Data update date
+      modified: Update date
       updatedAt: Update date
       title: Alphabetical order
       owner: Owner
@@ -451,7 +451,7 @@ const sortItems = computed(() => {
     search: Rechercher
     sort:
       createdAt: Date de création
-      dataUpdatedAt: Date de mise à jour des données
+      modified: Date de mise à jour
       updatedAt: Date de mise à jour
       title: Ordre alphabétique
       owner: Propriétaire

--- a/portal/app/components/page-element/applications/page-element-applications-list.vue
+++ b/portal/app/components/page-element/applications/page-element-applications-list.vue
@@ -32,7 +32,7 @@ if (!preview) {
     ids: element.mode === 'custom' ? ids.join(',') : undefined,
     publicationSites: 'data-fair-portals:' + portal.value._id,
     size: element.mode !== 'custom' ? element.limit : undefined,
-    sort: element.mode === 'lastUpdated' ? 'dataUpdatedAt:-1' : element.mode === 'lastCreated' ? 'createdAt:-1' : undefined
+    sort: element.mode === 'lastUpdated' ? 'updatedAt:-1' : element.mode === 'lastCreated' ? 'createdAt:-1' : undefined
   }))
 
   const applicationsFetch = useLocalFetch<ApplicationFetch>('/data-fair/api/v1/applications', { query: applicationsQuery })

--- a/portal/app/components/page-element/datasets/page-element-datasets-catalog.vue
+++ b/portal/app/components/page-element/datasets/page-element-datasets-catalog.vue
@@ -112,7 +112,7 @@ const {
 
 const sortItems = [
   { title: t('sort.createdAt'), value: 'createdAt' },
-  { title: t('sort.dataUpdatedAt'), value: 'dataUpdatedAt' },
+  { title: t('sort.modified'), value: 'modified' },
   { title: t('sort.title'), value: 'title' },
   { title: portalConfig.value?.labelsOverrides?.owner || t('sort.owner'), value: 'owner.departmentName' }
 ]
@@ -124,7 +124,7 @@ const sortItems = [
     datasetsCount: 'No dataset | {count} dataset | {count} datasets'
     sort:
       createdAt: Creation date
-      dataUpdatedAt: Data update date
+      modified: Update date
       title: Alphabetical order
       owner: Owner
 
@@ -133,7 +133,7 @@ const sortItems = [
     datasetsCount: 'Aucun jeu de données | {count} jeu de données | {count} jeux de données'
     sort:
       createdAt: Date de création
-      dataUpdatedAt: Date de mise à jour des données
+      modified: Date de mise à jour
       title: Ordre alphabétique
       owner: Propriétaire
 </i18n>

--- a/portal/app/components/page-element/datasets/page-element-datasets-list.vue
+++ b/portal/app/components/page-element/datasets/page-element-datasets-list.vue
@@ -34,7 +34,7 @@ if (!preview) {
     publicationSites: 'data-fair-portals:' + portal.value._id,
     truncate: 250,
     size: element.mode !== 'custom' ? element.limit : undefined,
-    sort: element.mode === 'lastUpdated' ? 'dataUpdatedAt:-1' : element.mode === 'lastCreated' ? 'createdAt:-1' : undefined
+    sort: element.mode === 'lastUpdated' ? 'modified:-1' : element.mode === 'lastCreated' ? 'createdAt:-1' : undefined
   }))
 
   const datasetsFetch = useLocalFetch<DatasetFetch>('/data-fair/api/v1/datasets', { query: datasetsQuery })

--- a/upgrade/2.23.0/datasets-catalog-default-sort.ts
+++ b/upgrade/2.23.0/datasets-catalog-default-sort.ts
@@ -1,0 +1,73 @@
+import type { UpgradeScript } from '@data-fair/lib-node/upgrade-scripts.js'
+import type { Page, PageElement } from '../../api/types/page/index.ts'
+
+export default {
+  description: "Migrate datasets-catalog defaultSort from 'dataUpdatedAt:-1' to 'modified:-1'",
+  async exec (db, debug) {
+    const pages = db.collection<Page>('pages')
+    let totalUpdated = 0
+
+    const pagesCursor = pages.find({})
+    for await (const page of pagesCursor) {
+      let pageModified = false
+
+      const migrateElement = (element: PageElement) => {
+        if (element.type !== 'datasets-catalog') return
+        const el = element as Record<string, unknown>
+        if (el.defaultSort === 'dataUpdatedAt:-1') {
+          el.defaultSort = 'modified:-1'
+          pageModified = true
+        }
+      }
+
+      await traversePageElements(page.config?.elements, migrateElement)
+      await traversePageElements(page.draftConfig?.elements, migrateElement)
+
+      if (pageModified) {
+        await pages.updateOne(
+          { _id: page._id },
+          {
+            $set: {
+              config: page.config,
+              draftConfig: page.draftConfig,
+              updatedAt: new Date().toISOString()
+            }
+          }
+        )
+        totalUpdated++
+      }
+    }
+
+    debug(`Migration completed: updated ${totalUpdated} pages`)
+  }
+} as UpgradeScript
+
+const traversePageElements = async (pageElements: PageElement[] | undefined, callback: (pageElement: PageElement) => Promise<void> | void) => {
+  if (!pageElements) return
+  for (const element of pageElements) {
+    await callback(element)
+    if (element.type === 'card') await traversePageElements(element.children, callback)
+    if (element.type === 'banner') await traversePageElements(element.children, callback)
+    if (element.type === 'responsive-grid') await traversePageElements(element.children, callback)
+    if (element.type === 'datasets-catalog') await traversePageElements(element.advancedFilters, callback)
+    if (element.type === 'applications-catalog') await traversePageElements(element.advancedFilters, callback)
+    if (element.type === 'reuses-catalog') await traversePageElements(element.advancedFilters, callback)
+
+    if (element.type === 'two-columns') {
+      await traversePageElements(element.children, callback)
+      await traversePageElements(element.children2, callback)
+    }
+
+    if (element.type === 'tabs') {
+      for (const tab of element.tabs) {
+        await traversePageElements(tab.children, callback)
+      }
+    }
+
+    if (element.type === 'expansion-panels') {
+      for (const tab of element.panels) {
+        await traversePageElements(tab.children, callback)
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Replaces `dataUpdatedAt:-1` with the unified `modified:-1` field for datasets sorting in the schema, catalog filters, datasets-catalog and datasets-list page elements, and i18n labels.
- Switches the applications `lastUpdated` mode to `updatedAt:-1` (applications do not expose `dataUpdatedAt`).
- Adds a 2.23.0 upgrade script that migrates existing pages' `datasets-catalog` `defaultSort` from `dataUpdatedAt:-1` to `modified:-1`, traversing nested containers (card, banner, two-columns, tabs, expansion-panels, responsive-grid, advancedFilters) in both `config` and `draftConfig`.