### PR TITLE
feat(portal): improve sitemap page accessibility and contextualization

### DIFF
--- a/portal/app/pages/sitemap.vue
+++ b/portal/app/pages/sitemap.vue
@@ -1,9 +1,12 @@
 <template>
   <layout-page>
     <v-container>
-      <h1 class="text-headline-large text-primary mb-2">
+      <component
+        :is="mainTitleTag"
+        class="text-headline-large text-primary mb-2"
+      >
         {{ t('sitemap') }}
-      </h1>
+      </component>
       <p class="text-body-large text-medium-emphasis mb-6">
         {{ pageDescription }}
       </p>
@@ -13,12 +16,13 @@
         class="mb-6"
         aria-labelledby="sitemap-nav-title"
       >
-        <h2
+        <component
+          :is="sectionTitleTag"
           id="sitemap-nav-title"
           class="text-title-large text-primary mb-3"
         >
           {{ t('sitemapSections.mainNav') }}
-        </h2>
+        </component>
         <ul style="list-style: none; padding-left: 0;">
           <li
             v-if="!allInternalPaths.has('/')"
@@ -39,12 +43,13 @@
         class="mb-6"
         aria-labelledby="sitemap-services-title"
       >
-        <h2
+        <component
+          :is="sectionTitleTag"
           id="sitemap-services-title"
           class="text-title-large text-primary mb-3"
         >
           {{ t('sitemapSections.services') }}
-        </h2>
+        </component>
         <ul style="list-style: none; padding-left: 0;">
           <li
             v-if="!session.user.value"
@@ -78,12 +83,13 @@
         class="mb-6"
         aria-labelledby="sitemap-legal-title"
       >
-        <h2
+        <component
+          :is="sectionTitleTag"
           id="sitemap-legal-title"
           class="text-title-large text-primary mb-3"
         >
           {{ t('sitemapSections.legal') }}
-        </h2>
+        </component>
         <ul style="list-style: none; padding-left: 0;">
           <sitemap-menu-item
             v-for="(item, i) in internalFooterLinks"
@@ -139,11 +145,16 @@
 
 <script setup lang="ts">
 import type { MenuItem, LinkItem } from '#api/types/portal'
+import type { HeadingTag } from '#api/types/page-elements/index.ts'
 
 const { t, locale } = useI18n()
 const session = useSession()
 const { portalConfig } = usePortalStore()
 const { resolveLink, setBreadcrumbs, isExternalLink } = useNavigationStore()
+
+const headerHasTitle = computed(() => !!(portalConfig.value.header?.show && portalConfig.value.header?.showTitle))
+const mainTitleTag = computed<HeadingTag>(() => headerHasTitle.value ? 'h2' : 'h1')
+const sectionTitleTag = computed<HeadingTag>(() => headerHasTitle.value ? 'h3' : 'h2')
 
 // Check which standard pages exist
 const standardPagesFetch = await useFetch<Record<string, boolean>>('/portal/api/pages/standard-exists', { watch: false })

--- a/portal/app/pages/sitemap.vue
+++ b/portal/app/pages/sitemap.vue
@@ -1,74 +1,138 @@
 <template>
   <layout-page>
     <v-container>
-      <h1 class="text-headline-large text-primary mb-6">
+      <h1 class="text-headline-large text-primary mb-2">
         {{ t('sitemap') }}
       </h1>
+      <p class="text-body-large text-medium-emphasis mb-6">
+        {{ t('description') }}
+      </p>
 
-      <ul style="list-style: none;">
-        <!-- Home always first -->
-        <li
-          v-if="!allInternalPaths.has('/')"
-          class="mb-2"
+      <section
+        v-if="hasMainNavSection"
+        class="mb-6"
+        aria-labelledby="sitemap-nav-title"
+      >
+        <h2
+          id="sitemap-nav-title"
+          class="text-title-large text-primary mb-3"
         >
-          <NuxtLink to="/">{{ t('home') }}</NuxtLink>
-        </li>
+          {{ t('sitemapSections.mainNav') }}
+        </h2>
+        <ul style="list-style: none; padding-left: 0;">
+          <li
+            v-if="!allInternalPaths.has('/')"
+            class="mb-2"
+          >
+            <NuxtLink to="/">{{ t('home') }}</NuxtLink>
+          </li>
+          <sitemap-menu-item
+            v-for="(item, i) in internalNavigationItems"
+            :key="`nav-${i}`"
+            :item="item"
+          />
+        </ul>
+      </section>
 
-        <!-- Navigation menu items -->
-        <sitemap-menu-item
-          v-for="(item, i) in internalNavigationItems"
-          :key="`nav-${i}`"
-          :item="item"
-        />
+      <section
+        v-if="hasServicesSection"
+        class="mb-6"
+        aria-labelledby="sitemap-services-title"
+      >
+        <h2
+          id="sitemap-services-title"
+          class="text-title-large text-primary mb-3"
+        >
+          {{ t('sitemapSections.services') }}
+        </h2>
+        <ul style="list-style: none; padding-left: 0;">
+          <li
+            v-if="!session.user.value"
+            class="mb-2"
+          >
+            <a :href="session.loginUrl()">{{ t('login') }}</a>
+          </li>
+          <li
+            v-if="standardPages['datasets'] && !allInternalPaths.has('/datasets')"
+            class="mb-2"
+          >
+            <NuxtLink to="/datasets">{{ t('datasets') }}</NuxtLink>
+          </li>
+          <li
+            v-if="standardPages['applications'] && !allInternalPaths.has('/applications')"
+            class="mb-2"
+          >
+            <NuxtLink to="/applications">{{ t('applications') }}</NuxtLink>
+          </li>
+          <li
+            v-if="standardPages['reuses'] && !allInternalPaths.has('/reuses')"
+            class="mb-2"
+          >
+            <NuxtLink to="/reuses">{{ t('reuses') }}</NuxtLink>
+          </li>
+        </ul>
+      </section>
 
-        <!-- Footer links -->
-        <sitemap-menu-item
-          v-for="(item, i) in internalFooterLinks"
-          :key="`footer-${i}`"
-          :item="item"
-        />
-
-        <!-- Footer important links -->
-        <sitemap-menu-item
-          v-for="(item, i) in internalFooterImportantLinks"
-          :key="`footer-important-${i}`"
-          :item="item"
-        />
-
-        <!-- Login page (only if not authenticated) -->
-        <li v-if="!session.user.value">
-          <a :href="session.loginUrl()">{{ t('login') }}</a>
-        </li>
-
-        <!-- Standard pages at the end -->
-        <li v-if="standardPages['datasets'] && !allInternalPaths.has('/datasets')">
-          <NuxtLink to="/datasets">{{ t('datasets') }}</NuxtLink>
-        </li>
-        <li v-if="standardPages['applications'] && !allInternalPaths.has('/applications')">
-          <NuxtLink to="/applications">{{ t('applications') }}</NuxtLink>
-        </li>
-        <li v-if="standardPages['reuses'] && !allInternalPaths.has('/reuses')">
-          <NuxtLink to="/reuses">{{ t('reuses') }}</NuxtLink>
-        </li>
-        <li v-if="standardPages.contact && !allInternalPaths.has('/contact')">
-          <NuxtLink to="/contact">{{ t('contact') }}</NuxtLink>
-        </li>
-        <li v-if="standardPages.accessibility && !allInternalPaths.has('/accessibility')">
-          <NuxtLink to="/accessibility">{{ t('accessibility') }}</NuxtLink>
-        </li>
-        <li v-if="standardPages['terms-of-service'] && !allInternalPaths.has('/terms-of-service')">
-          <NuxtLink to="/terms-of-service">{{ t('termsOfService') }}</NuxtLink>
-        </li>
-        <li v-if="standardPages['legal-notice'] && !allInternalPaths.has('/legal-notice')">
-          <NuxtLink to="/legal-notice">{{ t('legalNotice') }}</NuxtLink>
-        </li>
-        <li v-if="standardPages['privacy-policy'] && !allInternalPaths.has('/privacy-policy')">
-          <NuxtLink to="/privacy-policy">{{ t('privacyPolicy') }}</NuxtLink>
-        </li>
-        <li v-if="standardPages['cookie-policy'] && !allInternalPaths.has('/cookie-policy')">
-          <NuxtLink to="/cookie-policy">{{ t('cookiePolicy') }}</NuxtLink>
-        </li>
-      </ul>
+      <section
+        v-if="hasLegalSection"
+        class="mb-6"
+        aria-labelledby="sitemap-legal-title"
+      >
+        <h2
+          id="sitemap-legal-title"
+          class="text-title-large text-primary mb-3"
+        >
+          {{ t('sitemapSections.legal') }}
+        </h2>
+        <ul style="list-style: none; padding-left: 0;">
+          <sitemap-menu-item
+            v-for="(item, i) in internalFooterLinks"
+            :key="`footer-${i}`"
+            :item="item"
+          />
+          <sitemap-menu-item
+            v-for="(item, i) in internalFooterImportantLinks"
+            :key="`footer-important-${i}`"
+            :item="item"
+          />
+          <li
+            v-if="standardPages.contact && !allInternalPaths.has('/contact')"
+            class="mb-2"
+          >
+            <NuxtLink to="/contact">{{ t('contact') }}</NuxtLink>
+          </li>
+          <li
+            v-if="standardPages.accessibility && !allInternalPaths.has('/accessibility')"
+            class="mb-2"
+          >
+            <NuxtLink to="/accessibility">{{ t('accessibility') }}</NuxtLink>
+          </li>
+          <li
+            v-if="standardPages['terms-of-service'] && !allInternalPaths.has('/terms-of-service')"
+            class="mb-2"
+          >
+            <NuxtLink to="/terms-of-service">{{ t('termsOfService') }}</NuxtLink>
+          </li>
+          <li
+            v-if="standardPages['legal-notice'] && !allInternalPaths.has('/legal-notice')"
+            class="mb-2"
+          >
+            <NuxtLink to="/legal-notice">{{ t('legalNotice') }}</NuxtLink>
+          </li>
+          <li
+            v-if="standardPages['privacy-policy'] && !allInternalPaths.has('/privacy-policy')"
+            class="mb-2"
+          >
+            <NuxtLink to="/privacy-policy">{{ t('privacyPolicy') }}</NuxtLink>
+          </li>
+          <li
+            v-if="standardPages['cookie-policy'] && !allInternalPaths.has('/cookie-policy')"
+            class="mb-2"
+          >
+            <NuxtLink to="/cookie-policy">{{ t('cookiePolicy') }}</NuxtLink>
+          </li>
+        </ul>
+      </section>
     </v-container>
   </layout-page>
 </template>
@@ -88,7 +152,6 @@ const standardPages = computed(() => standardPagesFetch.data.value || {})
 // Collect all internal paths recursively
 const collectInternalPaths = (items: (MenuItem | LinkItem)[]): Set<string> => {
   const paths = new Set<string>()
-
   const processItem = (item: MenuItem | LinkItem) => {
     if (item.type === 'submenu' && 'children' in item && item.children) {
       item.children.forEach(processItem)
@@ -97,7 +160,6 @@ const collectInternalPaths = (items: (MenuItem | LinkItem)[]): Set<string> => {
       if (path) paths.add(path)
     }
   }
-
   items.forEach(processItem)
   return paths
 }
@@ -114,7 +176,6 @@ const filterInternalItems = (items: (MenuItem | LinkItem)[]): (MenuItem | LinkIt
       return item
     })
     .filter(Boolean) as (MenuItem | LinkItem)[]
-
   // Remove external links and any links resolving to '/sitemap'
   return filtered.filter(item => {
     if (item.type === 'submenu') return true // keep submenus
@@ -133,7 +194,6 @@ const internalFooterImportantLinks = computed(() => filterInternalItems(portalCo
 // All internal paths (to avoid duplicates)
 const allInternalPaths = computed(() => {
   const paths = new Set<string>()
-
   collectInternalPaths(portalConfig.value.menu.children).forEach(p => paths.add(p))
   if (portalConfig.value.footer.links) {
     collectInternalPaths(portalConfig.value.footer.links).forEach(p => paths.add(p))
@@ -143,6 +203,29 @@ const allInternalPaths = computed(() => {
   }
   return paths
 })
+
+// Section visibility (avoid orphan <h2> with empty <ul>)
+const hasMainNavSection = computed(() =>
+  !allInternalPaths.value.has('/') || internalNavigationItems.value.length > 0
+)
+
+const hasServicesSection = computed(() =>
+  !session.user.value ||
+  (standardPages.value['datasets'] && !allInternalPaths.value.has('/datasets')) ||
+  (standardPages.value['applications'] && !allInternalPaths.value.has('/applications')) ||
+  (standardPages.value['reuses'] && !allInternalPaths.value.has('/reuses'))
+)
+
+const hasLegalSection = computed(() =>
+  internalFooterLinks.value.length > 0 ||
+  internalFooterImportantLinks.value.length > 0 ||
+  (standardPages.value.contact && !allInternalPaths.value.has('/contact')) ||
+  (standardPages.value.accessibility && !allInternalPaths.value.has('/accessibility')) ||
+  (standardPages.value['terms-of-service'] && !allInternalPaths.value.has('/terms-of-service')) ||
+  (standardPages.value['legal-notice'] && !allInternalPaths.value.has('/legal-notice')) ||
+  (standardPages.value['privacy-policy'] && !allInternalPaths.value.has('/privacy-policy')) ||
+  (standardPages.value['cookie-policy'] && !allInternalPaths.value.has('/cookie-policy'))
+)
 
 setBreadcrumbs([{ type: 'standard', subtype: 'sitemap' }])
 
@@ -167,6 +250,10 @@ usePageSeo({
     privacyPolicy: Privacy Policy
     cookiePolicy: Cookie Policy
     login: Login Page
+    sitemapSections:
+      mainNav: Main Navigation
+      services: Data & Services
+      legal: Legal & Informational Links
   fr:
     sitemap: Plan du site
     description: Découvrez la structure complète du site et accédez directement aux pages de jeux de données, de visualisations, d'événements et d'actualités.
@@ -181,4 +268,8 @@ usePageSeo({
     privacyPolicy: Politique de confidentialité
     cookiePolicy: Politique de cookies
     login: Page de connexion
+    sitemapSections:
+      mainNav: Navigation principale
+      services: Services et données
+      legal: Informations légales et contact
 </i18n>

--- a/portal/app/pages/sitemap.vue
+++ b/portal/app/pages/sitemap.vue
@@ -5,7 +5,7 @@
         {{ t('sitemap') }}
       </h1>
       <p class="text-body-large text-medium-emphasis mb-6">
-        {{ t('description') }}
+        {{ pageDescription }}
       </p>
 
       <section
@@ -140,7 +140,7 @@
 <script setup lang="ts">
 import type { MenuItem, LinkItem } from '#api/types/portal'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const session = useSession()
 const { portalConfig } = usePortalStore()
 const { resolveLink, setBreadcrumbs, isExternalLink } = useNavigationStore()
@@ -148,6 +148,16 @@ const { resolveLink, setBreadcrumbs, isExternalLink } = useNavigationStore()
 // Check which standard pages exist
 const standardPagesFetch = await useFetch<Record<string, boolean>>('/portal/api/pages/standard-exists', { watch: false })
 const standardPages = computed(() => standardPagesFetch.data.value || {})
+
+const pageDescription = computed(() => {
+  const items: string[] = []
+  if (standardPages.value['datasets']) items.push(t('descriptionItems.datasets'))
+  if (standardPages.value['applications']) items.push(t('descriptionItems.applications'))
+  if (standardPages.value['reuses']) items.push(t('descriptionItems.reuses'))
+  if (items.length === 0) return t('description')
+  const list = new Intl.ListFormat(locale.value, { style: 'long', type: 'conjunction' }).format(items)
+  return t('descriptionWithCatalogs', { list })
+})
 
 // Collect all internal paths recursively
 const collectInternalPaths = (items: (MenuItem | LinkItem)[]): Set<string> => {
@@ -231,14 +241,19 @@ setBreadcrumbs([{ type: 'standard', subtype: 'sitemap' }])
 
 usePageSeo({
   title: t('sitemap') + ' - ' + portalConfig.value.title,
-  description: t('description')
+  description: pageDescription.value
 })
 </script>
 
 <i18n lang="yaml">
   en:
     sitemap: Sitemap
-    description: Discover the complete structure of the site and directly access dataset, visualization, event, and news pages.
+    description: Discover the complete structure of the site.
+    descriptionWithCatalogs: Discover the complete structure of the site and directly access the {list} pages.
+    descriptionItems:
+      datasets: dataset
+      applications: visualization
+      reuses: reuse
     datasets: Datasets
     applications: Applications
     reuses: Reuses
@@ -256,7 +271,12 @@ usePageSeo({
       legal: Legal & Informational Links
   fr:
     sitemap: Plan du site
-    description: Découvrez la structure complète du site et accédez directement aux pages de jeux de données, de visualisations, d'événements et d'actualités.
+    description: Découvrez la structure complète du site.
+    descriptionWithCatalogs: Découvrez la structure complète du site et accédez directement aux pages {list}.
+    descriptionItems:
+      datasets: de jeux de données
+      applications: de visualisations
+      reuses: de réutilisations
     datasets: Jeux de données
     applications: Visualisations
     reuses: Réutilisations


### PR DESCRIPTION
- Splits the sitemap page (`portal/app/pages/sitemap.vue`) into three labelled `<section>` blocks — *Main Navigation*, *Data & Services*, *Legal & Informational Links* — each with its own heading and `aria-labelledby`, so assistive technologies can navigate the page structure instead of a single flat `<ul>`.
- Makes heading levels adaptive: when the portal header already renders the site title as `<h1>`, the page title falls back to `<h2>` and section titles to `<h3>`; otherwise the page title stays `<h1>` and sections are `<h2>`. Avoids duplicate `<h1>` on portals that show the header title.
- Hides empty sections so screen-reader users never land on an orphan heading followed by no links (driven by `hasMainNavSection` / `hasServicesSection` / `hasLegalSection` computed flags).
- Makes the page description contextual: instead of always advertising "dataset, visualization, event, and news pages", the description is built from the catalog pages that actually exist on the portal (`/datasets`, `/applications`, `/reuses`), using `Intl.ListFormat` for proper locale-aware joining. Falls back to a generic description when no catalog pages are exposed.
- Adds matching `sitemapSections.*`, `descriptionItems.*` and `descriptionWithCatalogs` i18n keys in FR/EN.
