### PR TITLE
feat(portal): allow multiple sources in topics list page element

### DIFF
--- a/api/types/page-element-functional/schema.js
+++ b/api/types/page-element-functional/schema.js
@@ -96,19 +96,29 @@ export default {
         type: { const: 'topics' },
         uuid: { type: 'string', layout: 'none' },
         mode: {
-          type: 'string',
-          title: 'Source des thématiques',
-          default: 'datasets',
-          oneOf: [
-            { const: 'datasets', title: 'Jeux de données' },
-            { const: 'applications', title: 'Visualisations' }
-          ]
+          type: 'array',
+          title: 'Sources des thématiques',
+          description: 'Sélectionnez une ou plusieurs sources. Lorsque plusieurs sources sont sélectionnées, les thématiques sont fusionnées (les compteurs sont additionnés) et la redirection vers le catalogue est désactivée.',
+          default: ['datasets'],
+          minItems: 1,
+          uniqueItems: true,
+          items: {
+            type: 'string',
+            oneOf: [
+              { const: 'datasets', title: 'Jeux de données' },
+              { const: 'applications', title: 'Visualisations' }
+            ]
+          }
         },
         redirectPage: {
           type: 'boolean',
           title: 'Rediriger vers le catalogue',
           description: 'Si activé, cliquer sur une thématique redirigera vers le catalogue source des thématiques (Jeux de données ou Visualisations) avec le filtre de thématique. Sinon, les thématiques agiront en tant que filtres sur la page actuelle.',
-          layout: 'switch'
+          layout: {
+            comp: 'switch',
+            // Masqué quand plusieurs sources sont sélectionnées : on ne peut rediriger que vers un seul catalogue.
+            if: '!Array.isArray(parent.data?.mode) || parent.data?.mode.length <= 1'
+          }
         },
         centered: {
           type: 'boolean',
@@ -120,7 +130,7 @@ export default {
         rounded: { $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/rounded' },
         variant: {
           $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/variant',
-          layout: { if: 'parent.data?.redirectPage' }
+          layout: { if: 'parent.data?.redirectPage && (!Array.isArray(parent.data?.mode) || parent.data?.mode.length <= 1)' }
         },
         showIcon: {
           type: 'boolean',

--- a/portal/app/components/page-element/basic/page-element-topics.vue
+++ b/portal/app/components/page-element/basic/page-element-topics.vue
@@ -28,19 +28,20 @@ const { element } = defineProps({
 /*
  * Backward compatibility: `mode` was a single string ('datasets' | 'applications')
  * before becoming a non-empty array. Old portals (or API patches written against the
- * legacy shape) may still send a string — normalize to an array here.
+ * legacy shape) may still send a string — normalize to a non-empty tuple here.
  */
-// @ts-ignore - legacy data shape: mode may be a string instead of an array
-const rawMode: TopicMode | TopicMode[] | undefined = element.mode
-let modes: [TopicMode, ...TopicMode[]]
-if (Array.isArray(rawMode) && rawMode.length > 0) modes = rawMode as [TopicMode, ...TopicMode[]]
-else if (typeof rawMode === 'string') modes = [rawMode]
-else modes = ['datasets']
+const modes = computed<[TopicMode, ...TopicMode[]]>(() => {
+  // @ts-ignore - legacy data shape: mode may be a string instead of an array
+  const rawMode: TopicMode | TopicMode[] | undefined = element.mode
+  if (Array.isArray(rawMode) && rawMode.length > 0) return rawMode as [TopicMode, ...TopicMode[]]
+  if (typeof rawMode === 'string') return [rawMode]
+  return ['datasets']
+})
 
 // Redirection only makes sense with a single source: when multiple modes are selected
 // the option is hidden in the editor, but we also enforce it at runtime in case the
 // config was patched via the API with redirectPage=true and several modes.
-const redirectPage = !!element.redirectPage && modes.length === 1
+const redirectPage = computed(() => !!element.redirectPage && modes.value.length === 1)
 
 const { portal, preview } = usePortalStore()
 
@@ -58,7 +59,7 @@ type TopicItem = {
 let topicsItems: TopicItem[] | ComputedRef<TopicItem[]>
 
 if (!preview) {
-  const fetches = modes.map(m => useLocalFetch<{
+  const fetches = modes.value.map(m => useLocalFetch<{
     facets: {
       topics: {
         value: Omit<TopicItem, 'count'>,

--- a/portal/app/components/page-element/basic/page-element-topics.vue
+++ b/portal/app/components/page-element/basic/page-element-topics.vue
@@ -25,18 +25,7 @@ const { element } = defineProps({
   element: { type: Object as () => TopicsElement, required: true }
 })
 
-/*
- * Backward compatibility: `mode` was a single string ('datasets' | 'applications')
- * before becoming a non-empty array. Old portals (or API patches written against the
- * legacy shape) may still send a string — normalize to a non-empty tuple here.
- */
-const modes = computed<[TopicMode, ...TopicMode[]]>(() => {
-  // @ts-ignore - legacy data shape: mode may be a string instead of an array
-  const rawMode: TopicMode | TopicMode[] | undefined = element.mode
-  if (Array.isArray(rawMode) && rawMode.length > 0) return rawMode as [TopicMode, ...TopicMode[]]
-  if (typeof rawMode === 'string') return [rawMode]
-  return ['datasets']
-})
+const modes = computed<[TopicMode, ...TopicMode[]]>(() => element.mode ?? ['datasets'])
 
 // Redirection only makes sense with a single source: when multiple modes are selected
 // the option is hidden in the editor, but we also enforce it at runtime in case the

--- a/portal/app/components/page-element/basic/page-element-topics.vue
+++ b/portal/app/components/page-element/basic/page-element-topics.vue
@@ -6,11 +6,11 @@
     <topics-list
       :config="element"
       :topics="topicsItems"
-      :link="element.redirectPage ? {
+      :link="redirectPage ? {
         type: 'standard',
-        subtype: mode
+        subtype: modes[0]
       } : undefined"
-      :is-filters="!element.redirectPage"
+      :is-filters="!redirectPage"
     />
   </div>
 </template>
@@ -19,10 +19,28 @@
 import type { TopicsElement } from '#api/types/page-elements/index.ts'
 import { mdiHome, mdiBook } from '@mdi/js'
 
+type TopicMode = 'datasets' | 'applications'
+
 const { element } = defineProps({
   element: { type: Object as () => TopicsElement, required: true }
 })
-const mode = element.mode || 'datasets'
+
+/*
+ * Backward compatibility: `mode` was a single string ('datasets' | 'applications')
+ * before becoming a non-empty array. Old portals (or API patches written against the
+ * legacy shape) may still send a string — normalize to an array here.
+ */
+// @ts-ignore - legacy data shape: mode may be a string instead of an array
+const rawMode: TopicMode | TopicMode[] | undefined = element.mode
+let modes: [TopicMode, ...TopicMode[]]
+if (Array.isArray(rawMode) && rawMode.length > 0) modes = rawMode as [TopicMode, ...TopicMode[]]
+else if (typeof rawMode === 'string') modes = [rawMode]
+else modes = ['datasets']
+
+// Redirection only makes sense with a single source: when multiple modes are selected
+// the option is hidden in the editor, but we also enforce it at runtime in case the
+// config was patched via the API with redirectPage=true and several modes.
+const redirectPage = !!element.redirectPage && modes.length === 1
 
 const { portal, preview } = usePortalStore()
 
@@ -40,21 +58,32 @@ type TopicItem = {
 let topicsItems: TopicItem[] | ComputedRef<TopicItem[]>
 
 if (!preview) {
-  const datasetsFetch = useLocalFetch<{
+  const fetches = modes.map(m => useLocalFetch<{
     facets: {
       topics: {
         value: Omit<TopicItem, 'count'>,
         count: number
       }[]
     }
-  }>(`/data-fair/api/v1/${mode}`, {
+  }>(`/data-fair/api/v1/${m}`, {
     query: {
       facets: 'topics',
       size: 0,
       publicationSites: 'data-fair-portals:' + portal.value._id,
     }
+  }))
+  topicsItems = computed(() => {
+    // Merge topics from every source, summing counts for topics that appear in several catalogs.
+    const merged = new Map<string, TopicItem>()
+    for (const fetch of fetches) {
+      for (const facet of fetch.data.value?.facets.topics ?? []) {
+        const existing = merged.get(facet.value.id)
+        if (existing) existing.count += facet.count
+        else merged.set(facet.value.id, { ...facet.value, count: facet.count })
+      }
+    }
+    return Array.from(merged.values())
   })
-  topicsItems = computed(() => datasetsFetch.data.value?.facets.topics.map(facet => ({ ...facet.value, count: facet.count })) || [])
 } else {
   topicsItems = [
     { id: 'topic-1', title: 'Topic 1', count: 10, icon: { svgPath: mdiHome } },

--- a/upgrade/2.25.0/topics-mode-to-array.ts
+++ b/upgrade/2.25.0/topics-mode-to-array.ts
@@ -1,0 +1,70 @@
+import type { UpgradeScript } from '@data-fair/lib-node/upgrade-scripts.js'
+import type { Page, PageElement } from '../../api/types/page/index.ts'
+
+export default {
+  description: "Migrate topics page element 'mode' from string to single-item array",
+  async exec (db, debug) {
+    const pages = db.collection<Page>('pages')
+    let totalUpdated = 0
+
+    const pagesCursor = pages.find({})
+    for await (const page of pagesCursor) {
+      let pageModified = false
+
+      const migrateElement = (element: PageElement) => {
+        if (element.type !== 'topics') return
+        const el = element as Record<string, unknown>
+        if (typeof el.mode === 'string') {
+          el.mode = [el.mode]
+          pageModified = true
+        }
+      }
+
+      await traversePageElements(page.config?.elements, migrateElement)
+      await traversePageElements(page.draftConfig?.elements, migrateElement)
+
+      if (pageModified) {
+        await pages.updateOne(
+          { _id: page._id },
+          {
+            $set: {
+              config: page.config,
+              draftConfig: page.draftConfig,
+              updatedAt: new Date().toISOString()
+            }
+          }
+        )
+        totalUpdated++
+      }
+    }
+
+    debug(`Migration completed: updated ${totalUpdated} pages`)
+  }
+} as UpgradeScript
+
+const traversePageElements = async (pageElements: PageElement[] | undefined, callback: (pageElement: PageElement) => Promise<void> | void) => {
+  if (!pageElements) return
+  for (const element of pageElements) {
+    await callback(element)
+    if (element.type === 'card') await traversePageElements(element.children, callback)
+    if (element.type === 'banner') await traversePageElements(element.children, callback)
+    if (element.type === 'responsive-grid') await traversePageElements(element.children, callback)
+
+    if (element.type === 'two-columns') {
+      await traversePageElements(element.children, callback)
+      await traversePageElements(element.children2, callback)
+    }
+
+    if (element.type === 'tabs') {
+      for (const tab of element.tabs) {
+        await traversePageElements(tab.children, callback)
+      }
+    }
+
+    if (element.type === 'expansion-panels') {
+      for (const panel of element.panels) {
+        await traversePageElements(panel.children, callback)
+      }
+    }
+  }
+}


### PR DESCRIPTION
- The `mode` property of the topics page element is now a string array (`minItems: 1`) instead of a single string. A block can aggregate topics from both the datasets and applications catalogs.
- The `redirectPage` option is hidden when several sources are selected, since redirection only targets a single catalog.
- Adds an upgrade script that converts the legacy string value to a single-element array for backward compatibility.