### PR TITLE
feat(portal): option to merge dataset/application subpaths in analytics

### DIFF
--- a/api/types/portal-config/schema.js
+++ b/api/types/portal-config/schema.js
@@ -413,6 +413,12 @@ export default {
       properties: {
         tracker: {
           $ref: 'https://github.com/data-fair/portals/portal-config-analytics-tracker'
+        },
+        mergeDatasetAppPaths: {
+          type: 'boolean',
+          title: 'Fusionner les pages datasets/applications',
+          description: "Si activé, les sous-pages d'un dataset ou d'une application (ex: /datasets/123/table) seront comptabilisées comme la page parent (/datasets/123) dans les statistiques.",
+          default: false
         }
       }
     },

--- a/portal/app/plugins/05-analytics.client.ts
+++ b/portal/app/plugins/05-analytics.client.ts
@@ -47,7 +47,12 @@ export default defineNuxtPlugin(async () => {
       // from.name is absent on initial page load
       if (!from.name || from.path !== to.path) {
         // using path instead of title meta as it is what we did historically
-        analytics?.page({ title: to.path })
+        let pagePath = to.path
+        if (portal.config.analytics?.mergeDatasetAppPaths) {
+          const match = pagePath.match(/^\/(datasets|applications)\/[^/]+/)
+          if (match) pagePath = match[0]
+        }
+        analytics?.page({ title: pagePath })
       }
     })
   }


### PR DESCRIPTION
- Adds a new boolean option `analytics.mergeDatasetAppPaths` to the portal config (defaults to `false`, backward-compatible).
- When enabled, dataset and application subpages (e.g. `/datasets/123/table`, `/applications/abc/api-doc`) are reported as their parent page (`/datasets/123`, `/applications/abc`) in analytics.
- Useful to aggregate views of the same resource instead of splitting them across subtabs.