### PR TITLE
feat(portal): display dataset conformsTo schema metadata

### DIFF
--- a/api/types/index.ts
+++ b/api/types/index.ts
@@ -71,6 +71,11 @@ export type Dataset = {
     end?: string
   }
   frequency?: string
+  conformsTo?: {
+    title?: string
+    version?: string
+    url?: string
+  }
   customMetadata?: Record<string, string>
 
   attachments?: {

--- a/portal/app/components/dataset/dataset-metadata.vue
+++ b/portal/app/components/dataset/dataset-metadata.vue
@@ -131,6 +131,34 @@
         {{ t('frequencyLabels.' + dataset.frequency) }}
       </v-col>
 
+      <v-col
+        v-if="dataset.conformsTo && (dataset.conformsTo.title || dataset.conformsTo.url || dataset.conformsTo.version)"
+        v-bind="metadataColProps"
+      >
+        <div class="text-body-small text-medium-emphasis">{{ metadataLabel('conformsTo') }}</div>
+        <div class="d-flex align-center ga-2 flex-wrap">
+          <a
+            v-if="dataset.conformsTo.url"
+            :href="dataset.conformsTo.url"
+            rel="noopener"
+            target="_blank"
+            :title="(dataset.conformsTo.title || dataset.conformsTo.url) + ' - ' + t('newWindow')"
+            class="simple-link"
+          >
+            {{ dataset.conformsTo.title || dataset.conformsTo.url }}
+          </a>
+          <template v-else-if="dataset.conformsTo.title">
+            {{ dataset.conformsTo.title }}
+          </template>
+          <v-chip
+            v-if="dataset.conformsTo.version"
+            :text="dataset.conformsTo.version"
+            color="secondary"
+            size="small"
+          />
+        </div>
+      </v-col>
+
       <!-- Modified or dataUpdatedAt -->
       <v-col v-bind="metadataColProps">
         <div class="text-body-small text-medium-emphasis">{{ metadataLabel('modified') }}</div>
@@ -285,7 +313,7 @@ const customOwnerLabel = portalConfig.value.labelsOverrides?.owner
 
 const shouldShowActionButton = (button: ActionButtons[number]) => metadataConfig.value.actionButtons?.includes(button)
 
-type BaseMetadataSettings = Partial<Record<'keywords' | 'frequency' | 'temporal' | 'spatial' | 'modified' | 'creator',
+type BaseMetadataSettings = Partial<Record<'keywords' | 'frequency' | 'temporal' | 'spatial' | 'modified' | 'creator' | 'conformsTo',
   { active?: boolean; title?: string }
 >>
 
@@ -320,6 +348,7 @@ const metadataLabel = (key: keyof BaseMetadataSettings) => metadataSettings.data
       threeTimesAYear: '3 times a year'
       triennial: 'Every 3 years'
       weekly: 'Every week'
+    conformsTo: 'Schema:'
     keywords: 'Keywords:'
     license: 'License:'
     modified: 'Data last modified:'
@@ -366,6 +395,7 @@ const metadataLabel = (key: keyof BaseMetadataSettings) => metadataSettings.data
       threeTimesAYear: '3 fois par an'
       triennial: 'Tous les 3 ans'
       weekly: 'Chaque semaine'
+    conformsTo: 'Schéma :'
     keywords: 'Mots-clés :'
     license: 'Licence :'
     modified: 'Dernière mise à jour des données :'

--- a/portal/app/components/dataset/dataset-metadata.vue
+++ b/portal/app/components/dataset/dataset-metadata.vue
@@ -153,7 +153,7 @@
           <v-chip
             v-if="dataset.conformsTo.version"
             :text="dataset.conformsTo.version"
-            color="secondary"
+            :prepend-icon="mdiLabel"
             size="small"
           />
         </div>
@@ -282,7 +282,7 @@
 <script setup lang="ts">
 import type { Dataset } from '#api/types/index.ts'
 import type { ActionButtons } from '#api/types/portal-config'
-import { mdiCog, mdiMapMarker, mdiTableLarge } from '@mdi/js'
+import { mdiCog, mdiLabel, mdiMapMarker, mdiTableLarge } from '@mdi/js'
 import OwnerAvatar from '@data-fair/lib-vuetify/owner-avatar.vue'
 import formatBytes from '@data-fair/lib-vue/format/bytes.js'
 


### PR DESCRIPTION
Companion to data-fair#383 (introduces the `conformsTo` dataset metadata: external schema reference with `title`, `version`, `url`).

- Adds an optional `conformsTo` field on the portal-side `Dataset` type (`api/types/index.ts`).
- Renders the schema reference in the dataset metadata card (`portal/app/components/dataset/dataset-metadata.vue`), placed after the *frequency* row to match the order of metadata in the data-fair org settings:
  - Title displayed as a link to `url` (`target="_blank"`, `rel="noopener"`, `simple-link` style). Falls back to plain text when there is no URL; falls back to the URL itself as link label when there is no title.
  - Version shown as a small secondary `v-chip` to the right.
  - Row is hidden when `conformsTo` exists but all three sub-fields are empty.
- Label is resolved through the existing `metadata-settings` endpoint (`metadataLabel('conformsTo')`), so the per-org custom title configured in data-fair (*Paramètres → Qualité → Métadonnées → Schéma*) is honored. Default i18n label: "Schema:" / "Schéma :".
- `BaseMetadataSettings` extended with the `conformsTo` key so the typed label lookup compiles.