### PR TITLE
feat(agent): emit absolute links and _c_-prefixed geo filters in navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -958,9 +958,9 @@
       }
     },
     "node_modules/@data-fair/agent-tools-data-fair": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@data-fair/agent-tools-data-fair/-/agent-tools-data-fair-0.3.4.tgz",
-      "integrity": "sha512-aNuJLd5dxq7DPWy5GRAD416fYY8MYIHxnc9WFM3Q7XW+Ab3HUZ9ZSsYitRx1fB7YB2KEJTUmtUcCtgDNJyQ5kQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@data-fair/agent-tools-data-fair/-/agent-tools-data-fair-0.3.5.tgz",
+      "integrity": "sha512-FWVR9sXyrUIqhLzac42jPi/eg+gYC1Ve0Puj22yIE6AlcdjzUSfUPw4eF4sAD6P1QPpRIiKFr0PAnkhZpjwdaA==",
       "license": "AGPL-3.0-only"
     },
     "node_modules/@data-fair/frame": {

--- a/portal/app/composables/agent/geo-tools.ts
+++ b/portal/app/composables/agent/geo-tools.ts
@@ -42,7 +42,7 @@ export function useAgentGeoTools (locale: Ref<string>) {
 
   useAgentTool({
     name: 'get_user_geolocation',
-    description: 'Get the current geographic position of the user using the browser Geolocation API. Returns latitude, longitude, and accuracy. The user may be prompted to grant location permission.',
+    description: 'Get the current geographic position of the user using the browser Geolocation API. Returns longitude, latitude, and accuracy (for geo_distance/bbox filters use lon,lat order). The user may be prompted to grant location permission.',
     annotations: { title: getUserGeolocationTitle[locale.value] ?? getUserGeolocationTitle.en, readOnlyHint: true },
     inputSchema: {
       type: 'object' as const,
@@ -67,8 +67,8 @@ export function useAgentGeoTools (locale: Ref<string>) {
 
         const { latitude, longitude, accuracy, altitude, altitudeAccuracy } = position.coords
         const parts = [
-          `**Latitude**: ${latitude}`,
           `**Longitude**: ${longitude}`,
+          `**Latitude**: ${latitude}`,
           `**Accuracy**: ${Math.round(accuracy)} m`
         ]
         if (altitude != null) {

--- a/portal/app/composables/agent/navigation-tools.ts
+++ b/portal/app/composables/agent/navigation-tools.ts
@@ -116,7 +116,7 @@ export function useAgentNavigationTools ({ locale, portalConfig, navigationStore
       sections.push(
         '**Detail pages** (use list_datasets, list_applications, list_events, list_news, or list_reuses to find slugs/refs):\n' +
         '- Dataset detail: /datasets/{ref}\n' +
-        '- Dataset table: /datasets/{ref}/table — accepts filter query params (same format as search_data filters: column_key + suffix like nom_search, age_lte, ville_eq). Also accepts q (full-text search), sort, select, bbox, geo_distance, date_match. Use the filterQuery from dataset_data subagent Context directly as the query parameter.\n' +
+        '- Dataset table: /datasets/{ref}/table — accepts filter query params (same format as search_data filters: column_key + suffix like nom_search, age_lte, ville_eq). Also accepts _c_q (full-text search), sort, select, _c_bbox, _c_geo_distance, _c_date_match. The `_c_` prefix on q/bbox/geo_distance/date_match is required for URL sync. Use the filterQuery from dataset_data subagent Context directly as the query parameter.\n' +
         '- Dataset map: /datasets/{ref}/map — for geolocalized datasets, accepts the same filter query params as the table page\n' +
         '- Dataset API doc: /datasets/{ref}/api-doc\n' +
         '- Application detail: /applications/{ref}\n' +
@@ -157,7 +157,7 @@ export function useAgentNavigationTools ({ locale, portalConfig, navigationStore
         },
         query: {
           type: 'string' as const,
-          description: 'Optional query string to append to the URL (without leading "?"). For dataset table pages, use the filterQuery from the dataset_data subagent Context. Example: "nom_search=Jean&age_lte=30&q=Paris"'
+          description: 'Optional query string to append to the URL (without leading "?"). For dataset table pages, use the filterQuery from the dataset_data subagent Context. Geo/full-text filters need the `_c_` prefix. Example: "nom_search=Jean&_c_q=Paris&_c_geo_distance=2.35,48.85,10km"'
         }
       },
       required: ['path'] as const

--- a/portal/app/composables/agent/portal-prompt-context.ts
+++ b/portal/app/composables/agent/portal-prompt-context.ts
@@ -3,12 +3,15 @@ import type { PortalConfig } from '#api/types/portal-config'
 /** Portal context appended to every agent's system prompt (domain/owner/title). */
 export function portalPromptContext (portalConfig: PortalConfig, ownerName?: string): string[] {
   const parts: string[] = ['Tu es un assistant IA intégré à un portail de données Data Fair.']
-  const domain = import.meta.client ? window.location.hostname : ''
-  if (domain) parts.push(`Le nom de domaine de ce portail est "${domain}".`)
+  const origin = import.meta.client ? window.location.origin : ''
+  if (origin) {
+    parts.push(`Le nom de domaine de ce portail est "${window.location.hostname}".`)
+    parts.push(`Présente les liens vers les pages du portail en URL absolue, préfixée par "${origin}", jamais en chemin relatif.`)
+  }
   if (ownerName) parts.push(`Ce portail est géré par "${ownerName}".`)
   if (portalConfig.title) parts.push(`Le titre de ce portail est "${portalConfig.title}".`)
   return parts
 }
 
 /** Hint shared with the global agent about offering filtered navigation views. */
-export const navigateToFilteredViewHint = 'Quand tu effectues une recherche ou un filtrage de données dans un jeu de données, propose systématiquement à l\'utilisateur de naviguer vers une vue filtrée. Le sous-agent dataset_data inclut dans sa section Context un champ filterQuery (query string URL) et un champ columns (colonnes pertinentes). Utilise l\'outil navigate avec la filterQuery comme paramètre query en y ajoutant select=col1,col2,col3 à partir des clés de columns. Propose la vue tableau /datasets/{datasetId}/table, et si les données sont géolocalisées (présence de bbox, geo_distance dans la filterQuery, ou colonnes géographiques dans columns) propose également la vue carte /datasets/{datasetId}/map.'
+export const navigateToFilteredViewHint = 'Quand tu filtres ou recherches des données dans un jeu de données, propose à l\'utilisateur des liens vers les vues filtrées : la vue tableau /datasets/{datasetId}/table, et si les données sont géolocalisées la vue carte /datasets/{datasetId}/map. Utilise le champ filterQuery du sous-agent dataset_data comme query string (ses filtres sont déjà préfixés "_c_"), en y ajoutant select=<clés de columns>.'

--- a/portal/app/composables/agent/portal-prompt-context.ts
+++ b/portal/app/composables/agent/portal-prompt-context.ts
@@ -6,7 +6,7 @@ export function portalPromptContext (portalConfig: PortalConfig, ownerName?: str
   const origin = import.meta.client ? window.location.origin : ''
   if (origin) {
     parts.push(`Le nom de domaine de ce portail est "${window.location.hostname}".`)
-    parts.push(`Présente les liens vers les pages du portail en URL absolue, préfixée par "${origin}", jamais en chemin relatif.`)
+    parts.push(`Présente toujours les liens vers les pages du portail comme des liens markdown avec une URL absolue, par exemple \`[Voir la carte](${origin}/datasets/mon-jeu/map)\` — jamais un chemin relatif ni une URL brute non formatée.`)
   }
   if (ownerName) parts.push(`Ce portail est géré par "${ownerName}".`)
   if (portalConfig.title) parts.push(`Le titre de ce portail est "${portalConfig.title}".`)

--- a/portal/app/composables/agent/portal-prompt-context.ts
+++ b/portal/app/composables/agent/portal-prompt-context.ts
@@ -14,4 +14,4 @@ export function portalPromptContext (portalConfig: PortalConfig, ownerName?: str
 }
 
 /** Hint shared with the global agent about offering filtered navigation views. */
-export const navigateToFilteredViewHint = 'Quand tu filtres ou recherches des données dans un jeu de données, propose à l\'utilisateur des liens vers les vues filtrées : la vue tableau /datasets/{datasetId}/table, et si les données sont géolocalisées la vue carte /datasets/{datasetId}/map. Utilise le champ filterQuery du sous-agent dataset_data comme query string (ses filtres sont déjà préfixés "_c_"), en y ajoutant select=<clés de columns>.'
+export const navigateToFilteredViewHint = 'Quand tu proposes un lien vers une vue filtrée d\'un jeu de données, privilégie fortement le champ filterQuery renvoyé par le sous-agent dataset_data (déjà validé et préfixé "_c_", en y ajoutant select=<clés de columns>) plutôt que des filtres assemblés à la main, et vérifie que totalResults > 0 avant de proposer le lien. Vue tableau : /datasets/{datasetId}/table ; vue carte (si géolocalisé) : /datasets/{datasetId}/map.'


### PR DESCRIPTION
Refine the portal AI agent's navigation and geo tooling so it produces links that actually work when clicked.

**What changed:**
- Navigation tool now documents that `q`/`bbox`/`geo_distance`/`date_match` query params require the `_c_` prefix to survive embed URL sync.
- `get_user_geolocation` returns longitude before latitude and notes the `lon,lat` order expected by geo_distance/bbox filters.
- System prompt instructs the agent to present portal links as absolute markdown URLs (never relative paths or bare URLs), and `navigateToFilteredViewHint` now strongly prefers the validated, `_c_`-prefixed `filterQuery` from the dataset_data subagent and requires `totalResults > 0` before proposing a link.
- Bump `@data-fair/agent-tools-data-fair` 0.3.4 -> 0.3.5 (within existing `^0.3.0` range).

**Why:** the agent was generating filtered-view links that lost their filters on URL sync (only `_c_`-prefixed params survive) and emitted relative/bare links that didn't render as clickable.

**Regression risks:**
- Prompt-only behavior change: the agent now always emits absolute markdown links and requires totalResults > 0 before linking. Any eval/test checking for relative paths or bare URLs will need updating.
- `get_user_geolocation` output field order changed (lon before lat); consumed by the LLM, not parsed positionally, so low risk -- verify no snapshot asserts order.
