### PR TITLE
feat(portal): assistant navigation prefers dataset slugs over ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -958,9 +958,9 @@
       }
     },
     "node_modules/@data-fair/agent-tools-data-fair": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@data-fair/agent-tools-data-fair/-/agent-tools-data-fair-0.3.5.tgz",
-      "integrity": "sha512-FWVR9sXyrUIqhLzac42jPi/eg+gYC1Ve0Puj22yIE6AlcdjzUSfUPw4eF4sAD6P1QPpRIiKFr0PAnkhZpjwdaA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@data-fair/agent-tools-data-fair/-/agent-tools-data-fair-0.4.1.tgz",
+      "integrity": "sha512-jOJUBKgEyxiWfwrFb3IFvvVAqijdHnVA1T+PhtM4MBvEAVC+14dJMD3PwOKw9/qp7kcZ9RVpm5IPop9b4Pr7BQ==",
       "license": "AGPL-3.0-only"
     },
     "node_modules/@data-fair/frame": {
@@ -24425,7 +24425,7 @@
       "dependencies": {
         "@analytics/google-analytics": "^1.1.0",
         "@analytics/google-tag-manager": "^0.6.0",
-        "@data-fair/agent-tools-data-fair": "^0.3.0",
+        "@data-fair/agent-tools-data-fair": "^0.4.1",
         "@data-fair/frame": "^0.18.1",
         "@data-fair/lib-common-types": "^1.20.2",
         "@data-fair/lib-node": "^2.12.1",

--- a/portal/app/composables/agent/navigation-tools.ts
+++ b/portal/app/composables/agent/navigation-tools.ts
@@ -114,13 +114,13 @@ export function useAgentNavigationTools ({ locale, portalConfig, navigationStore
       }
 
       sections.push(
-        '**Detail pages** (use list_datasets, list_applications, list_events, list_news, or list_reuses to find slugs/refs):\n' +
-        '- Dataset detail: /datasets/{ref}\n' +
-        '- Dataset table: /datasets/{ref}/table — accepts filter query params (same format as search_data filters: column_key + suffix like nom_search, age_lte, ville_eq). Also accepts _c_q (full-text search), sort, select, _c_bbox, _c_geo_distance, _c_date_match. The `_c_` prefix on q/bbox/geo_distance/date_match is required for URL sync. Use the filterQuery from dataset_data subagent Context directly as the query parameter.\n' +
-        '- Dataset map: /datasets/{ref}/map — for geolocalized datasets, accepts the same filter query params as the table page\n' +
-        '- Dataset API doc: /datasets/{ref}/api-doc\n' +
-        '- Application detail: /applications/{ref}\n' +
-        '- Application full view: /applications/{ref}/full\n' +
+        '**Detail pages** (use list_datasets, list_applications, list_events, list_news, or list_reuses to find slugs). The {slug} placeholders below are the human-readable slug returned by those tools; for datasets and applications fall back to the `id` only when no slug exists:\n' +
+        '- Dataset detail: /datasets/{slug}\n' +
+        '- Dataset table: /datasets/{slug}/table — accepts filter query params (same format as search_data filters: column_key + suffix like nom_search, age_lte, ville_eq). Also accepts _c_q (full-text search), sort, select, _c_bbox, _c_geo_distance, _c_date_match. The `_c_` prefix on q/bbox/geo_distance/date_match is required for URL sync. Use the filterQuery from dataset_data subagent Context directly as the query parameter.\n' +
+        '- Dataset map: /datasets/{slug}/map — for geolocalized datasets, accepts the same filter query params as the table page\n' +
+        '- Dataset API doc: /datasets/{slug}/api-doc\n' +
+        '- Application detail: /applications/{slug}\n' +
+        '- Application full view: /applications/{slug}/full\n' +
         '- Event detail: /event/{slug}\n' +
         '- News detail: /news/{slug}\n' +
         '- Reuse detail: /reuses/{slug}'
@@ -146,7 +146,7 @@ export function useAgentNavigationTools ({ locale, portalConfig, navigationStore
 
   useAgentTool({
     name: 'navigate',
-    description: 'Navigate to a page in the portal. Use list_pages to discover available paths, and list_datasets, list_applications, list_events, list_news, or list_reuses to find resource slugs/refs. Optionally pass query parameters. IMPORTANT: when you search or filter data from a dataset, always offer to navigate the user to the filtered table view by passing the same filter parameters as query params to /datasets/{ref}/table.',
+    description: 'Navigate to a page in the portal. Use list_pages to discover available paths, and list_datasets, list_applications, list_events, list_news, or list_reuses to find resource slugs/refs — prefer the human-readable `slug` over the `id` when building dataset and application paths. Optionally pass query parameters. IMPORTANT: when you search or filter data from a dataset, always offer to navigate the user to the filtered table view by passing the same filter parameters as query params to /datasets/{slug}/table.',
     annotations: { title: t('navigateToPage') },
     inputSchema: {
       type: 'object' as const,

--- a/portal/app/composables/agent/portal-prompt-context.ts
+++ b/portal/app/composables/agent/portal-prompt-context.ts
@@ -14,4 +14,4 @@ export function portalPromptContext (portalConfig: PortalConfig, ownerName?: str
 }
 
 /** Hint shared with the global agent about offering filtered navigation views. */
-export const navigateToFilteredViewHint = 'Quand tu proposes un lien vers une vue filtrée d\'un jeu de données, privilégie fortement le champ filterQuery renvoyé par le sous-agent dataset_data (déjà validé et préfixé "_c_", en y ajoutant select=<clés de columns>) plutôt que des filtres assemblés à la main, et vérifie que totalResults > 0 avant de proposer le lien. Vue tableau : /datasets/{datasetId}/table ; vue carte (si géolocalisé) : /datasets/{datasetId}/map.'
+export const navigateToFilteredViewHint = 'Quand tu proposes un lien vers une vue filtrée d\'un jeu de données, privilégie fortement le champ filterQuery renvoyé par le sous-agent dataset_data (déjà validé et préfixé "_c_", en y ajoutant select=<clés de columns>) plutôt que des filtres assemblés à la main, et vérifie que totalResults > 0 avant de proposer le lien. Utilise de préférence le slug du jeu de données plutôt que son id dans le chemin. Vue tableau : /datasets/{slug}/table ; vue carte (si géolocalisé) : /datasets/{slug}/map.'

--- a/portal/package.json
+++ b/portal/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@analytics/google-analytics": "^1.1.0",
     "@analytics/google-tag-manager": "^0.6.0",
-    "@data-fair/agent-tools-data-fair": "^0.3.0",
+    "@data-fair/agent-tools-data-fair": "^0.4.1",
     "@data-fair/frame": "^0.18.1",
     "@data-fair/lib-common-types": "^1.20.2",
     "@data-fair/lib-node": "^2.12.1",


### PR DESCRIPTION
Make the portal AI assistant build links to **datasets** and **applications** using their human-readable `slug` instead of the opaque `id`. Applications/events/news/reuses already used slugs; datasets were the gap.

**Why:** navigation links the assistant emits should use resource slugs rather than ids, in general — they're readable and stable in portal URLs.

**What changed:**
- Bump `@data-fair/agent-tools-data-fair` `^0.3.0` → `^0.4.1`, whose `list_datasets` now selects and prints the dataset `slug` alongside `id`.
- Update the agent navigation prompts (`list_pages` detail-page patterns, `navigate` description, `navigateToFilteredViewHint`) to use `/datasets/{slug}` / `/applications/{slug}` and prefer slug over id (id only as fallback when no slug exists).

**Regression risks:**
- The dependency bump (0.3.5 → 0.4.1) touches three tools the portal imports — `list-datasets`, `get-dataset-schema`, `dataset-data-subagent` — but every change is **slug-additive** (new `slug` in selects/output, one extra prompt line); no existing field or behavior changed.
- The assistant now emits slug-based dataset URLs and may pass a slug where a `datasetId` was previously expected (e.g. `describe_dataset`, `search_data`). This is safe because the data-fair API resolves a dataset by id *or* slug (`api/src/datasets/utils/index.js:223`, `_uniqueRefs`), and data-fair already uses slug as the ref for foreign public URLs like a portal.
- Prompt-only behavior change otherwise — no runtime code paths in this repo were modified.