### PR TITLE
refactor(portal): streamline agent prompt and reuse shared filterQuery unwrap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -958,9 +958,9 @@
       }
     },
     "node_modules/@data-fair/agent-tools-data-fair": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@data-fair/agent-tools-data-fair/-/agent-tools-data-fair-0.5.0.tgz",
-      "integrity": "sha512-fnYrApCKhT6VBf3Vza4KWjgWZnHUqo5HrcXeBQDdH6vkEt7BE2mpU7ry3Dspp979J+mbqUD13fd/cxcQPEpHhg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@data-fair/agent-tools-data-fair/-/agent-tools-data-fair-0.6.0.tgz",
+      "integrity": "sha512-WXbs0SzccZU0WxmQmzCfj/xHtdWj0Rg0d3jkjFX1Z+MP3YFNx5GuM4tzWs6aEkgQdQnCAjwZ7VnRUARXWfl3lA==",
       "license": "AGPL-3.0-only"
     },
     "node_modules/@data-fair/frame": {
@@ -24425,7 +24425,7 @@
       "dependencies": {
         "@analytics/google-analytics": "^1.1.0",
         "@analytics/google-tag-manager": "^0.6.0",
-        "@data-fair/agent-tools-data-fair": "^0.5.0",
+        "@data-fair/agent-tools-data-fair": "^0.6.0",
         "@data-fair/frame": "^0.18.1",
         "@data-fair/lib-common-types": "^1.20.2",
         "@data-fair/lib-node": "^2.12.1",

--- a/portal/app/components/agent-chat.vue
+++ b/portal/app/components/agent-chat.vue
@@ -58,7 +58,7 @@ import { defineAsyncComponent, computed } from 'vue'
 import type { $Fetch } from 'nitropack/types'
 import type { PortalConfig } from '#api/types/portal-config'
 import { type Account, getAccountRole } from '@data-fair/lib-common-types/session/index.js'
-import { portalPromptContext, navigateToFilteredViewHint } from '../composables/agent/portal-prompt-context'
+import { portalPromptContext } from '../composables/agent/portal-prompt-context'
 
 const DfAgentChatDrawer = defineAsyncComponent(() => import('@data-fair/lib-vuetify-agents/DfAgentChatDrawer.vue'))
 const DfAgentChatToggle = defineAsyncComponent(() => import('@data-fair/lib-vuetify-agents/DfAgentChatToggle.vue'))
@@ -91,9 +91,8 @@ const canSee = computed(() => {
 
 const systemPrompt = computed(() => {
   const base = agentChat.value?.systemPrompt || ''
-  const parts = [base, ...portalPromptContext(props.portalConfig, props.owner.name)]
-  parts.push(navigateToFilteredViewHint)
-  return parts.join('\n')
+  const parts = [base, ...portalPromptContext(props.portalConfig, props.owner.name, !!base)]
+  return parts.filter(Boolean).join('\n')
 })
 
 </script>

--- a/portal/app/components/page-element/functional/page-element-custom-agent.vue
+++ b/portal/app/components/page-element/functional/page-element-custom-agent.vue
@@ -54,12 +54,12 @@ const canSee = computed(() => {
 // the chat URL and routes navigate-messages internally. We only compose the
 // effective prompt: block prompt + portal context + focus datasets + containment.
 const systemPrompt = computed(() => {
-  const parts = [element.systemPrompt || '', ...portalPromptContext(portalConfig.value, owner.value?.name)]
+  const parts = [element.systemPrompt || '', ...portalPromptContext(portalConfig.value, owner.value?.name, !!element.systemPrompt)]
   if (element.focusDatasets?.length) {
     const list = element.focusDatasets.map((d: { id: string, title?: string }) => `"${d.title ?? d.id}" (id: ${d.id})`).join(', ')
     parts.push(`Concentre tes explorations de données sur ces jeux de données : ${list}. Tu peux explorer le reste du catalogue uniquement si l'utilisateur le demande explicitement.`)
   }
   parts.push("Ton travail est limité au contexte de cette page. N'utilise pas l'outil de navigation pour quitter la page, sauf si l'utilisateur le demande explicitement.")
-  return parts.join('\n')
+  return parts.filter(Boolean).join('\n')
 })
 </script>

--- a/portal/app/composables/agent/navigation-tools.ts
+++ b/portal/app/composables/agent/navigation-tools.ts
@@ -5,6 +5,7 @@ import type { LinkItem } from '#api/types/common-links/index.ts'
 import type { PortalConfig } from '#api/types/portal-config'
 import { useAgentTool } from '@data-fair/lib-vue-agents'
 import { useReactiveSearchParams } from '@data-fair/lib-vue/reactive-search-params.js'
+import { unwrapFilterQuery } from '@data-fair/agent-tools-data-fair/_utils'
 import { createAgentTranslator } from './utils'
 
 type BreadcrumbItems = NonNullable<VBreadcrumbs['$props']['items']>
@@ -166,16 +167,7 @@ export function useAgentNavigationTools ({ locale, portalConfig, navigationStore
       try {
         // Defensive unwrap: the agent is told to pass the dataset_data subagent's filterQuery
         // value directly, but it sometimes wraps it as "filterQuery=<the whole query string>".
-        // Detect that single-param case and use the inner string as the actual query.
-        // TODO: replace with unwrapFilterQuery from @data-fair/agent-tools-data-fair/_utils
-        // once that package is bumped to a version that exports it.
-        let queryString = params.query as string | undefined
-        if (queryString) {
-          const match = /^filterQuery=(.+)$/s.exec(queryString.trim())
-          if (match) {
-            try { queryString = decodeURIComponent(match[1]) } catch { queryString = match[1] }
-          }
-        }
+        const queryString = unwrapFilterQuery(params.query as string | undefined)
         const query = queryString ? Object.fromEntries(new URLSearchParams(queryString)) : undefined
         await router.push(query ? { path: params.path, query } : params.path)
         await new Promise(resolve => setTimeout(resolve, 500))

--- a/portal/app/composables/agent/navigation-tools.ts
+++ b/portal/app/composables/agent/navigation-tools.ts
@@ -164,7 +164,19 @@ export function useAgentNavigationTools ({ locale, portalConfig, navigationStore
     },
     execute: async (params) => {
       try {
-        const query = params.query ? Object.fromEntries(new URLSearchParams(params.query as string)) : undefined
+        // Defensive unwrap: the agent is told to pass the dataset_data subagent's filterQuery
+        // value directly, but it sometimes wraps it as "filterQuery=<the whole query string>".
+        // Detect that single-param case and use the inner string as the actual query.
+        // TODO: replace with unwrapFilterQuery from @data-fair/agent-tools-data-fair/_utils
+        // once that package is bumped to a version that exports it.
+        let queryString = params.query as string | undefined
+        if (queryString) {
+          const match = /^filterQuery=(.+)$/s.exec(queryString.trim())
+          if (match) {
+            try { queryString = decodeURIComponent(match[1]) } catch { queryString = match[1] }
+          }
+        }
+        const query = queryString ? Object.fromEntries(new URLSearchParams(queryString)) : undefined
         await router.push(query ? { path: params.path, query } : params.path)
         await new Promise(resolve => setTimeout(resolve, 500))
         const currentRoute = router.currentRoute.value

--- a/portal/app/composables/agent/navigation-tools.ts
+++ b/portal/app/composables/agent/navigation-tools.ts
@@ -147,7 +147,7 @@ export function useAgentNavigationTools ({ locale, portalConfig, navigationStore
 
   useAgentTool({
     name: 'navigate',
-    description: 'Navigate to a page in the portal. Use list_pages to discover available paths, and list_datasets, list_applications, list_events, list_news, or list_reuses to find resource slugs/refs — prefer the human-readable `slug` over the `id` when building dataset and application paths. Optionally pass query parameters. IMPORTANT: when you search or filter data from a dataset, always offer to navigate the user to the filtered table view by passing the same filter parameters as query params to /datasets/{slug}/table.',
+    description: 'Navigate to a page in the portal. Use list_pages to discover available paths, and list_datasets, list_applications, list_events, list_news, or list_reuses to find resource slugs/refs — prefer the human-readable `slug` over the `id` when building dataset and application paths. Optionally pass query parameters. IMPORTANT: when you search or filter data from a dataset, offer to navigate the user to the filtered table view at /datasets/{slug}/table by passing the same filter parameters as query params — but only when the search returned results (totalResults > 0).',
     annotations: { title: t('navigateToPage') },
     inputSchema: {
       type: 'object' as const,
@@ -158,7 +158,7 @@ export function useAgentNavigationTools ({ locale, portalConfig, navigationStore
         },
         query: {
           type: 'string' as const,
-          description: 'Optional query string to append to the URL (without leading "?"). For dataset table/map pages, pass the filterQuery from the dataset_data subagent Context verbatim — do not build or edit the filter parameters yourself.'
+          description: 'Optional query string to append to the URL (without leading "?"). For dataset table/map pages, pass the filterQuery from the dataset_data subagent Context verbatim — do not build or edit the filter parameters yourself. You may additionally append `select=<column keys>` to choose which columns are displayed, but do not otherwise alter the filter syntax.'
         }
       },
       required: ['path'] as const

--- a/portal/app/composables/agent/portal-prompt-context.ts
+++ b/portal/app/composables/agent/portal-prompt-context.ts
@@ -1,17 +1,31 @@
 import type { PortalConfig } from '#api/types/portal-config'
 
-/** Portal context appended to every agent's system prompt (domain/owner/title). */
-export function portalPromptContext (portalConfig: PortalConfig, ownerName?: string): string[] {
-  const parts: string[] = ['Tu es un assistant IA intégré à un portail de données Data Fair.']
+/**
+ * Portal context appended to every agent's system prompt.
+ *
+ * `hasCustomBase` tells us whether the caller already prepended a portal-configured
+ * base prompt: when it did, that base establishes the assistant's identity, so we
+ * skip our own generic identity line to avoid repeating it. When it did not, we
+ * provide the canonical identity line ourselves (the downstream agents component
+ * only falls back to its default base prompt when the whole prompt is empty, which
+ * it never is here — so identity must come from us).
+ */
+export function portalPromptContext (portalConfig: PortalConfig, ownerName?: string, hasCustomBase = false): string[] {
+  const parts: string[] = []
+  if (!hasCustomBase) parts.push('Tu es un assistant IA intégré à un portail de données Data Fair.')
+
+  // Single fact line (title / owner / domain) instead of three sentences: shorter
+  // and keeps the prompt prefix homogeneous across users for better prompt caching.
+  const hostname = import.meta.client ? window.location.hostname : ''
+  const descr: string[] = []
+  if (portalConfig.title) descr.push(`intitulé « ${portalConfig.title} »`)
+  if (ownerName) descr.push(`géré par « ${ownerName} »`)
+  if (hostname) descr.push(`accessible sur ${hostname}`)
+  if (descr.length) parts.push(`Ce portail est ${descr.join(', ')}.`)
+
   const origin = import.meta.client ? window.location.origin : ''
   if (origin) {
-    parts.push(`Le nom de domaine de ce portail est "${window.location.hostname}".`)
     parts.push(`Présente toujours les liens vers les pages du portail comme des liens markdown avec une URL absolue, par exemple \`[Voir la carte](${origin}/datasets/mon-jeu/map)\` — jamais un chemin relatif ni une URL brute non formatée.`)
   }
-  if (ownerName) parts.push(`Ce portail est géré par "${ownerName}".`)
-  if (portalConfig.title) parts.push(`Le titre de ce portail est "${portalConfig.title}".`)
   return parts
 }
-
-/** Hint shared with the global agent about offering filtered navigation views. */
-export const navigateToFilteredViewHint = 'Quand tu proposes un lien vers une vue filtrée d\'un jeu de données, utilise le champ filterQuery renvoyé par le sous-agent dataset_data tel quel ; ne fabrique pas de filtres à la main et ne modifie pas la syntaxe de ses paramètres (tu peux seulement y ajouter select=<clés de columns>). Vérifie que totalResults > 0 avant de proposer le lien. Utilise de préférence le slug du jeu de données plutôt que son id dans le chemin. Vue tableau : /datasets/{slug}/table ; vue carte (si géolocalisé) : /datasets/{slug}/map.'

--- a/portal/package.json
+++ b/portal/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@analytics/google-analytics": "^1.1.0",
     "@analytics/google-tag-manager": "^0.6.0",
-    "@data-fair/agent-tools-data-fair": "^0.5.0",
+    "@data-fair/agent-tools-data-fair": "^0.6.0",
     "@data-fair/frame": "^0.18.1",
     "@data-fair/lib-common-types": "^1.20.2",
     "@data-fair/lib-node": "^2.12.1",


### PR DESCRIPTION
Refine the portal AI agent prompt and navigation tooling:

- Defensively unwrap the agent's occasional `filterQuery=<whole query string>`
  double-wrapping in the `navigate` tool, via the shared `unwrapFilterQuery`
  helper (bumps `@data-fair/agent-tools-data-fair` 0.5.0 → 0.6.0, which exports it).
- Move the filtered-view navigation rules (pass filterQuery verbatim, `select=`,
  `totalResults > 0`) into the `navigate` tool description, dropping the separate
  `navigateToFilteredViewHint` constant.
- Compact the portal-context prompt: skip the generic identity line when a
  portal-configured base prompt already provides it, and collapse owner/title/
  domain into a single fact line for a more homogeneous, cache-friendly prefix.

**Why:** tighten and deduplicate the agent system prompt, and reuse the upstream
helper instead of a local copy.

**Regression risks:**
- Identity-line dedup: when a custom base prompt is configured the generic
  "Tu es un assistant IA…" line is now omitted — fine as long as configured base
  prompts establish identity themselves.
- `unwrapFilterQuery` runs on every `navigate` query; safe because `filterQuery`
  isn't a real query param, so legitimate queries never start with `filterQuery=`.
- The portal-context lines every agent sees changed shape (three sentences → one);
  cosmetic for the model, but it alters every agent's prompt prefix.
