### PR TITLE
feat(portal): disable catalog sort during text search

### DIFF
--- a/portal/app/components/catalog-filters.vue
+++ b/portal/app/components/catalog-filters.vue
@@ -192,6 +192,7 @@
       :density="config.filters?.density ?? portalConfig.defaults?.density"
       :rounded="config.filters?.rounded ?? portalConfig.defaults?.rounded"
       :drawer="drawer"
+      :disabled="!!filters.search.value"
     />
   </v-col>
 </template>

--- a/portal/app/components/catalog-layout.vue
+++ b/portal/app/components/catalog-layout.vue
@@ -90,6 +90,7 @@
             :items="sortItems"
             :density="element.filters?.density || 'comfortable'"
             :rounded="element.filters?.rounded"
+            :disabled="!!search"
             @update:sort="$emit('update:sort', $event)"
             @update:order="$emit('update:order', $event)"
           />
@@ -183,6 +184,9 @@ defineSlots<{
 
 const { portalConfig, preview } = usePortalStore()
 const { t } = useI18n()
+
+// Active text search disables the sort control (results are ranked by relevance)
+const search = useStringSearchParam('q')
 
 const headingTag = computed(() => {
   let level = 1

--- a/portal/app/components/catalog-sort.vue
+++ b/portal/app/components/catalog-sort.vue
@@ -1,67 +1,77 @@
 <template>
-  <v-select
-    :model-value="sort"
-    :items="items"
-    :label="t('sortBy')"
-    :density="density"
-    :rounded="rounded"
-    variant="outlined"
-    hide-details
-    clearable
-    @update:model-value="$emit('update:sort', $event)"
-    @click:clear="$emit('update:order', undefined)"
+  <!-- Wrapper carries the disabled cursor + native title: a disabled v-select
+       has pointer-events:none, so the hover lands on this div instead. -->
+  <div
+    :style="disabled ? { cursor: 'not-allowed' } : undefined"
+    :title="disabled ? t('sortDisabledRelevance') : undefined"
   >
-    <template v-if="!drawer" #append>
-      <v-btn-toggle
-        :model-value="order"
-        :density="density"
-        :rounded="rounded"
-        variant="outlined"
-        class="h-100"
-        divided
-        mandatory
-        @update:model-value="onOrderChange"
-      >
-        <v-btn
-          value="-1"
-          :icon="mdiSortDescending"
-          :title="t('descending')"
-          stacked
-        />
-        <v-btn
-          value="1"
-          :icon="mdiSortAscending"
-          :title="t('ascending')"
-          stacked
-        />
-      </v-btn-toggle>
-    </template>
-  </v-select>
+    <v-select
+      :model-value="sort"
+      :items="items"
+      :label="t('sortBy')"
+      :density="density"
+      :rounded="rounded"
+      :disabled="disabled"
+      variant="outlined"
+      hide-details
+      clearable
+      @update:model-value="$emit('update:sort', $event)"
+      @click:clear="$emit('update:order', undefined)"
+    >
+      <template v-if="!drawer" #append>
+        <v-btn-toggle
+          :model-value="order"
+          :density="density"
+          :rounded="rounded"
+          :disabled="disabled"
+          variant="outlined"
+          class="h-100"
+          divided
+          mandatory
+          @update:model-value="onOrderChange"
+        >
+          <v-btn
+            value="-1"
+            :icon="mdiSortDescending"
+            :title="t('descending')"
+            stacked
+          />
+          <v-btn
+            value="1"
+            :icon="mdiSortAscending"
+            :title="t('ascending')"
+            stacked
+          />
+        </v-btn-toggle>
+      </template>
+    </v-select>
 
-  <v-btn-toggle
-    v-if="drawer"
-    :model-value="order"
-    :density="density"
-    :rounded="rounded"
-    variant="outlined"
-    class="w-100 mt-6"
-    divided
-    mandatory
-    @update:model-value="onOrderChange"
-  >
-    <v-btn
-      value="-1"
-      :icon="mdiSortDescending"
-      :title="t('descending')"
-      class="flex-grow-1"
-    />
-    <v-btn
-      value="1"
-      :icon="mdiSortAscending"
-      :title="t('ascending')"
-      class="flex-grow-1"
-    />
-  </v-btn-toggle>
+    <v-btn-toggle
+      v-if="drawer"
+      :model-value="order"
+      :density="density"
+      :rounded="rounded"
+      :disabled="disabled"
+      variant="outlined"
+      class="w-100 mt-6"
+      divided
+      mandatory
+      @update:model-value="onOrderChange"
+    >
+      <v-btn
+        value="-1"
+        :icon="mdiSortDescending"
+        :title="t('descending')"
+        class="flex-grow-1"
+      />
+      <v-btn
+        value="1"
+        :icon="mdiSortAscending"
+        :title="t('ascending')"
+        class="flex-grow-1"
+      />
+    </v-btn-toggle>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -74,6 +84,7 @@ defineProps<{
   density?: 'default' | 'comfortable' | 'compact'
   rounded?: string | number | boolean
   drawer?: boolean
+  disabled?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -91,8 +102,10 @@ en:
   sortBy: Sort by
   ascending: Ascending order
   descending: Descending order
+  sortDisabledRelevance: 'Sorting is disabled during a search: results are sorted by relevance'
 fr:
   sortBy: Trier par
   ascending: Ordre croissant
   descending: Ordre décroissant
+  sortDisabledRelevance: 'Tri désactivé pendant une recherche : les résultats sont triés par pertinence'
 </i18n>

--- a/portal/app/components/page-element/applications/page-element-applications-catalog.vue
+++ b/portal/app/components/page-element/applications/page-element-applications-catalog.vue
@@ -72,7 +72,8 @@ const {
     if (filters.baseApplication.value?.length) query['base-application'] = filters.baseApplication.value.join(',')
     if (filters.topics.value?.length) query.topics = filters.topics.value.join(',')
     if (filters.owners.value?.length) query.owner = filters.owners.value.join(',')
-    if (sortValue && !(filters.search.value && sortValue === element.defaultSort)) query.sort = sortValue
+    // No sort during a text search: let data-fair rank results by relevance
+    if (sortValue && !filters.search.value) query.sort = sortValue
     return query
   },
   mockDataFactory: () => {

--- a/portal/app/components/page-element/datasets/page-element-datasets-catalog.vue
+++ b/portal/app/components/page-element/datasets/page-element-datasets-catalog.vue
@@ -93,7 +93,8 @@ const {
     if (filters.keywords.value?.length) query.keywords = filters.keywords.value.join(',')
     if (filters.owners.value?.length) query.owner = filters.owners.value.join(',')
     if (filters.ids.value?.length) query.ids = filters.ids.value.join(',')
-    if (sortValue && !(filters.search.value && sortValue === element.defaultSort)) query.sort = sortValue
+    // No sort during a text search: let data-fair rank results by relevance
+    if (sortValue && !filters.search.value) query.sort = sortValue
     return query
   },
   mockDataFactory: () => {

--- a/portal/app/components/page-element/events/page-element-event-catalog.vue
+++ b/portal/app/components/page-element/events/page-element-event-catalog.vue
@@ -63,7 +63,8 @@ const {
       page
     }
     if (filters.search.value) query.q = filters.search.value
-    if (sortValue && !(filters.search.value && sortValue === element.defaultSort)) query.sort = sortValue
+    // No sort during a text search: let data-fair rank results by relevance
+    if (sortValue && !filters.search.value) query.sort = sortValue
     if (filters.includePast.value || element.includePast) query.includePast = 'true'
     return query
   },

--- a/portal/app/components/page-element/news/page-element-news-catalog.vue
+++ b/portal/app/components/page-element/news/page-element-news-catalog.vue
@@ -57,7 +57,8 @@ const {
       page
     }
     if (filters.search.value) query.q = filters.search.value
-    if (sortValue && !(filters.search.value && sortValue === element.defaultSort)) query.sort = sortValue
+    // No sort during a text search: let data-fair rank results by relevance
+    if (sortValue && !filters.search.value) query.sort = sortValue
     return query
   },
   mockDataFactory: () => Array.from({ length: 6 }, (_, i) => ({

--- a/portal/app/components/page-element/reuses/page-element-reuses-catalog.vue
+++ b/portal/app/components/page-element/reuses/page-element-reuses-catalog.vue
@@ -60,7 +60,8 @@ const {
       page
     }
     if (filters.search.value) query.q = filters.search.value
-    if (sortValue && !(filters.search.value && sortValue === element.defaultSort)) query.sort = sortValue
+    // No sort during a text search: let data-fair rank results by relevance
+    if (sortValue && !filters.search.value) query.sort = sortValue
     return query
   },
   mockDataFactory: () => Array.from({ length: 6 }, (_, i) => ({

--- a/portal/app/composables/use-catalog.ts
+++ b/portal/app/composables/use-catalog.ts
@@ -50,8 +50,9 @@ export function useCatalog<T, F extends Record<string, FilterRef>> (
   //   - Default sort is invisible: not shown in the UI (dropdown stays empty)
   //     and not in the URL (useStringSearchParam deletes the key when value
   //     equals its default).
-  //   - On text search, consumers drop `sort` from the query when it matches
-  //     the default so data-fair can rank by relevance.
+  //   - On text search, consumers drop `sort` from the query entirely and the
+  //     UI disables the sort control, so data-fair ranks by relevance. The
+  //     chosen sort is kept in the URL and restored once the search is cleared.
   // Seed sort/order from the URL only when the active sort differs from the
   // default, so the dropdown reflects a user-chosen non-default value on load.
   const [initialField, initialOrder] = sortFilter.value !== defaultSort


### PR DESCRIPTION
Disable (and grey out) the catalog sort control while a text search is active, and stop sending any `sort` to data-fair during search so results are ranked by relevance.

**Why:** during a text search the only meaningful ordering is search relevance; letting the user pick a sort (or silently keeping their previous one) fought against that.

- `catalog-sort.vue`: new `disabled` prop greying out the select + order toggle; wrapper `<div>` carries the `not-allowed` cursor and a native-title tooltip explaining why (a disabled v-select has `pointer-events:none`, so the hover must land on the wrapper).
- `catalog-layout.vue` / `catalog-filters.vue`: pass `:disabled` based on the active `q` search param.
- The five `page-element-*-catalog.vue` query builders now drop `sort` whenever a search is active (previously only when the sort equalled the default).

**Regression risks:**
- Behavior change: a user-chosen *non-default* sort was previously still sent to data-fair during a search; now it is dropped entirely. The chosen sort stays in the URL and is restored once the search is cleared — verify that round-trip.
- `catalog-sort.vue` went from a multi-root (fragment) template to a single wrapping `<div>`. Each usage nests it inside a width-constrained `v-col`, so layout should be unchanged, but worth an eyeball in drawer mode (the `w-100` order toggle) and the standard sort-beside-count row.
