### PR TITLE
feat(portal): rework header config and add primary-logo centering

### DIFF
--- a/api/types/page-element-functional/schema.js
+++ b/api/types/page-element-functional/schema.js
@@ -536,7 +536,8 @@ export default {
         showSocial: {
           type: 'boolean',
           layout: 'switch',
-          title: 'Afficher les liens de réseaux sociaux'
+          title: 'Afficher les liens de réseaux sociaux',
+          description: "Aucun lien n'est affiché tant qu'aucun réseau social n'est renseigné dans la configuration du portail (« Paramètres généraux › Réseaux sociaux »)."
         },
         mb: { $ref: 'https://github.com/data-fair/portals/page-elements-defs#/$defs/margin-bottom' },
         sendButton: {

--- a/api/types/portal-config-footer/schema.js
+++ b/api/types/portal-config-footer/schema.js
@@ -72,6 +72,7 @@ export default {
     socialPosition: {
       type: 'string',
       title: 'Position des réseaux sociaux',
+      description: "Aucun lien n'est affiché tant qu'aucun réseau social n'est renseigné dans « Paramètres généraux › Réseaux sociaux ».",
       default: 'none',
       oneOf: [
         { const: 'none', title: 'Aucun' },

--- a/api/types/portal-config-header/schema.js
+++ b/api/types/portal-config-header/schema.js
@@ -3,7 +3,31 @@ export default {
   'x-exports': [],
   title: 'Header',
   type: 'object',
-  layout: { title: null },
+  layout: {
+    title: null,
+    // Two cards: "Options" for header-level display settings, "Contenu" for
+    // what the header shows. Inside each card, nested arrays group fields into
+    // discrete rows so half-width (cols md:6) fields only pair with siblings of
+    // the same group (a field left alone stays on its own line).
+    children: [
+      {
+        comp: 'card',
+        title: 'Options',
+        children: ['show', 'color', 'keepOnScroll']
+      },
+      {
+        comp: 'card',
+        title: 'Contenu',
+        if: 'data?.show',
+        children: [
+          'showSocial',
+          ['logoPrimaryType', 'logoPrimary', 'logoPrimaryMobile', 'logoPrimaryLink'],
+          ['logoPrimaryCentered', 'showTitle'],
+          ['logoSecondary', 'logoSecondaryLink']
+        ]
+      }
+    ]
+  },
   properties: {
     show: {
       type: 'boolean',
@@ -11,16 +35,25 @@ export default {
       title: "Afficher l'entête",
       default: true
     },
+    showSocial: {
+      type: 'boolean',
+      title: 'Afficher les liens de réseaux sociaux',
+      description: "Aucun lien n'est affiché tant qu'aucun réseau social n'est renseigné dans « Paramètres généraux › Réseaux sociaux ».",
+      layout: {
+        if: 'parent.data?.show',
+        comp: 'switch'
+      }
+    },
     logoPrimaryType: {
       type: 'string',
       title: 'Logo principal',
       default: 'default',
       layout: {
         if: 'parent.data?.show',
-        switch: [{
-          if: 'parent.data?.logoPrimaryType === "local"',
-          cols: { md: 6 }
-        }]
+        switch: [
+          { if: 'parent.data?.show && parent.data?.logoPrimaryType === "local"', cols: { md: 6 } },
+          { if: 'parent.data?.show && parent.data?.logoPrimaryType === "default"', cols: { md: 4 } }
+        ]
       },
       oneOf: [
         { const: 'default', title: 'Utiliser le logo principal' },
@@ -63,6 +96,9 @@ export default {
       required: ['_id', 'name', 'mimeType'],
       layout: {
         if: 'parent.data?.show && parent.data?.logoPrimaryType !== "hidden"',
+        switch: [
+          { if: 'parent.data?.show && parent.data?.logoPrimaryType === "default"', cols: { md: 4 } }
+        ],
         slots: {
           component: {
             name: 'image-upload',
@@ -92,16 +128,40 @@ export default {
       description: "Lien vers lequel l'utilisateur sera redirigé en cliquant sur le logo. Par défaut, il sera redirigé vers la page d'accueil.",
       layout: {
         if: 'parent.data?.show && parent.data?.logoPrimaryType !== "hidden"',
+        switch: [
+          { if: 'parent.data?.show && parent.data?.logoPrimaryType === "default"', cols: { md: 4 } }
+        ],
         props: { clearable: true },
         cols: { md: 6 }
       }
+    },
+    logoPrimaryCentered: {
+      type: 'boolean',
+      title: 'Centrer le logo principal',
+      description: "Centre le logo principal dans l'entête. Le titre du portail et le logo secondaire ne sont alors pas affichés.",
+      layout: {
+        if: 'parent.data?.show && parent.data?.logoPrimaryType !== "hidden"',
+        comp: 'switch',
+        cols: { md: 6 }
+      },
+      default: false
+    },
+    showTitle: {
+      type: 'boolean',
+      title: 'Afficher le titre du portail',
+      layout: {
+        if: 'parent.data?.show && !(parent.data?.logoPrimaryType !== "hidden" && parent.data?.logoPrimaryCentered)',
+        comp: 'switch',
+        cols: { md: 6 }
+      },
+      default: true
     },
     logoSecondary: {
       type: 'object',
       title: 'Logo secondaire',
       required: ['_id', 'name', 'mimeType'],
       layout: {
-        if: 'parent.data?.show',
+        if: 'parent.data?.show && !(parent.data?.logoPrimaryType !== "hidden" && parent.data?.logoPrimaryCentered)',
         slots: {
           component: {
             name: 'image-upload',
@@ -131,27 +191,8 @@ export default {
       title: 'Lien au clic sur le logo secondaire',
       description: "Lien vers lequel sera redirigé l'utilisateur lors du clic sur le logo secondaire.",
       layout: {
-        if: 'parent.data?.show',
+        if: 'parent.data?.show && !(parent.data?.logoPrimaryType !== "hidden" && parent.data?.logoPrimaryCentered)',
         props: { clearable: true },
-        cols: { md: 6 }
-      }
-    },
-    showTitle: {
-      type: 'boolean',
-      title: 'Afficher le titre du portail',
-      layout: {
-        if: 'parent.data?.show',
-        comp: 'switch',
-        cols: { md: 6 }
-      },
-      default: true
-    },
-    showSocial: {
-      type: 'boolean',
-      title: 'Afficher les liens de réseaux sociaux',
-      layout: {
-        if: 'parent.data?.show',
-        comp: 'switch',
         cols: { md: 6 }
       }
     },

--- a/api/types/portal-config/schema.js
+++ b/api/types/portal-config/schema.js
@@ -100,35 +100,29 @@ export default {
             if: 'data?.headerHomeActive',
             children: [
               {
-
                 cols: { md: 6 },
-                comp: 'card',
-                title: 'Options',
+                title: 'Toutes les pages',
                 children: ['header']
               },
               {
                 cols: { md: 6 },
-                comp: 'card',
-                title: 'Options - Accueil',
+                title: "Page d'accueil",
                 children: ['headerHome']
               },
               {
-                name: 'app-bar-preview'
+                name: 'app-bar-preview',
+                props: { title: 'Toutes les pages' }
               },
               {
                 name: 'app-bar-preview',
-                props: { home: true }
+                props: { home: true, title: "Page d'accueil" }
               }
             ]
           },
           {
             if: '!data?.headerHomeActive',
             children: [
-              {
-                comp: 'card',
-                title: 'Options',
-                children: ['header']
-              },
+              'header',
               { name: 'app-bar-preview' }
             ]
           },

--- a/portal/app/components/layout/layout-header.vue
+++ b/portal/app/components/layout/layout-header.vue
@@ -7,27 +7,29 @@
     >
       <social-links :links="portalConfig.socialLinks" />
     </v-row>
-    <v-row class="align-center mt-0">
+    <v-row :class="['align-center mt-0', { 'justify-center': logoCentered }]">
       <layout-header-logo
         v-if="logo"
         :logo="logo"
         :link="headerConfig.logoPrimaryLink"
       />
-      <v-spacer v-if="!headerConfig.showTitle" />
-      <v-col
-        v-else
-        class="text-center"
-      >
-        <h1 class="font-weight-bold portal-title">
-          {{ portalConfig.title }}
-        </h1>
-      </v-col>
-      <layout-header-logo
-        v-if="headerConfig.logoSecondary && !$vuetify.display.mdAndDown"
-        :logo="headerConfig.logoSecondary"
-        :link="headerConfig.logoSecondaryLink"
-        is-secondary
-      />
+      <template v-if="!logoCentered">
+        <v-spacer v-if="!headerConfig.showTitle" />
+        <v-col
+          v-else
+          class="text-center"
+        >
+          <h1 class="font-weight-bold portal-title">
+            {{ portalConfig.title }}
+          </h1>
+        </v-col>
+        <layout-header-logo
+          v-if="headerConfig.logoSecondary && !$vuetify.display.mdAndDown"
+          :logo="headerConfig.logoSecondary"
+          :link="headerConfig.logoSecondaryLink"
+          is-secondary
+        />
+      </template>
     </v-row>
   </v-container>
 </template>
@@ -45,8 +47,9 @@ const display = useDisplay()
  * Logo selection rules:
  * - If primary type is hidden: no logo.
  * - On mobile:
- *   - with title: use only logoPrimaryMobile (no fallback to primary logo)
- *   - without title: use logoPrimaryMobile, fallback to primary logo
+ *   - with title shown: use only logoPrimaryMobile (no fallback to primary logo)
+ *   - with title hidden (showTitle off or centering on): use logoPrimaryMobile,
+ *     fallback to primary logo so the centered logo stays visible.
  * - On desktop: use primary logo only.
  */
 const logo = computed(() => {
@@ -58,12 +61,22 @@ const logo = computed(() => {
       ? portalConfig.value.logo || null
       : null
 
+  // Centering hides the title, so treat it as "title hidden" for the mobile fallback.
+  const titleHidden = headerConfig.logoPrimaryCentered || !headerConfig.showTitle
+
   if (display.xs.value) {
-    return headerConfig.logoPrimaryMobile || (headerConfig.showTitle ? null : primaryLogo)
+    return headerConfig.logoPrimaryMobile || (titleHidden ? primaryLogo : null)
   }
 
   return primaryLogo
 })
+
+/**
+ * Center the primary logo when explicitly enabled and a logo is displayed.
+ * In that case the portal title and the secondary logo are not rendered
+ * (the config form hides those options when centering is on).
+ */
+const logoCentered = computed(() => !!logo.value && headerConfig.logoPrimaryCentered)
 
 </script>
 

--- a/ui/src/pages/portals/[id]/index.vue
+++ b/ui/src/pages/portals/[id]/index.vue
@@ -52,7 +52,7 @@
 
           <template #app-bar-preview="context">
             <preview
-              :append-title="context.home ? t('appBarPreview') + ' - ' + t('home'): t('appBarPreview')"
+              :append-title="context.title ?? (context.home ? t('appBarPreview') + ' - ' + t('home'): t('appBarPreview'))"
               no-padding
             >
               <layout-app-bar


### PR DESCRIPTION
Rework the header configuration and add a primary-logo centering option.

- Reorganize the header config form into two cards: "Options" (display, color, keep-on-scroll) and "Contenu" (logos, title, social links).
- Add a "Center primary logo" option: when enabled and a primary logo is shown, the logo is centered and the portal title and secondary logo are no longer displayed (both in the form and in the rendered header).
- Add empty-state descriptions for social links in the footer and contact-form schemas.

**Why:** give the header a clearer two-card layout and let portals display a single centered logo instead of the logo / title / secondary-logo arrangement.

**Regression risks:**
- On mobile (xs), if centering is enabled without a mobile logo set, the primary logo can resolve to null (the stored `showTitle` still being `true` by default) and the title reappears — diverging from desktop where centering hides the title. To confirm.
- Existing portals are unaffected: `logoPrimaryCentered` defaults to `false`, so the rendering stays identical.
- The config editor layout (portals-manager) changes (cards now come from the header schema, column titles renamed) — visual only, no impact on the rendered portal.
