### PR TITLE
perf(portal): render catalog first page during SSR to avoid hydration layout shift

### DIFF
--- a/portal/app/composables/use-catalog.ts
+++ b/portal/app/composables/use-catalog.ts
@@ -62,41 +62,46 @@ export function useCatalog<T, F extends Record<string, FilterRef>> (
   const order = ref<'-1' | '1' | undefined>(initialOrder)
 
   const currentPage = ref(1)
-  const displayedItems = ref<T[]>([]) as Ref<T[]>
   const loading = ref(false)
 
   const query = computed(() => config.buildQuery(filters, sortFilter.value, currentPage.value, pageSize))
 
-  const itemsFetch = useFetch<FetchResult<T>>(config.endpoint, { query, watch: false })
+  const itemsFetch = useLocalFetch<FetchResult<T>>(config.endpoint, { query, watch: false })
   const itemsCount = computed(() => itemsFetch.data.value?.count || 0)
   const totalPages = computed(() => Math.ceil((itemsFetch.data.value?.count || 0) / pageSize))
 
-  const refreshItems = async (mode: 'replace' | 'append') => {
+  // Items accumulated across "load more" pages (infinite scroll); undefined when
+  // not accumulating, so the displayed list comes straight from the latest
+  // fetch. Reading itemsFetch.data through a computed (evaluated at render time,
+  // once Nuxt has resolved the SSR data) is what puts the first page into the
+  // server-rendered HTML and avoids the large layout shift on hydration.
+  const appendedItems = ref<T[]>()
+  const displayedItems = computed<T[]>(() => appendedItems.value ?? itemsFetch.data.value?.results ?? []) as Ref<T[]>
+
+  const fetchPage = async () => {
     loading.value = true
     try {
       await itemsFetch.refresh()
-      const results = itemsFetch.data.value?.results
-      if (!results) return
-      if (mode === 'append') displayedItems.value.push(...results)
-      else displayedItems.value = [...results]
     } finally {
       loading.value = false
     }
   }
 
   const goToPage = async (page: number) => {
+    appendedItems.value = undefined
     currentPage.value = page
-    await refreshItems('replace')
+    await fetchPage()
   }
 
   const loadMore = async (paginationPosition: string = 'none') => {
     if (loading.value || paginationPosition !== 'none') return
     if (displayedItems.value.length >= (itemsFetch.data.value?.count || 0)) return
+    // Freeze the items shown so far, then append the next page once it arrives.
+    appendedItems.value = [...displayedItems.value]
     currentPage.value++
-    await refreshItems('append')
+    await fetchPage()
+    appendedItems.value = [...(appendedItems.value ?? []), ...(itemsFetch.data.value?.results ?? [])]
   }
-
-  onMounted(async () => await refreshItems('replace'))
 
   // When user changes sort/order in UI, update the URL-bound sortFilter
   watch([sort, order], () => {
@@ -108,8 +113,9 @@ export function useCatalog<T, F extends Record<string, FilterRef>> (
   // Watch all filters + sort to reset pagination and re-fetch
   const filterRefs = [...Object.values(filters), sortFilter]
   watch(filterRefs, async () => {
+    appendedItems.value = undefined
     currentPage.value = 1
-    await refreshItems('replace')
+    await fetchPage()
     if (config.analyticsCategory && filters.search) {
       const searchRef = filters.search as WritableComputedRef<string, string>
       if (searchRef.value) {

--- a/portal/server/plugins/sd-resources.ts
+++ b/portal/server/plugins/sd-resources.ts
@@ -1,6 +1,3 @@
-// dynamic CSP modifications based on portal config
-// similar to https://github.com/Baroshem/nuxt-security/blob/main/src/runtime/nitro/plugins/50-updateCsp.ts
-
 import memoize from 'memoizee'
 import axios from '@data-fair/lib-node/axios.js'
 


### PR DESCRIPTION
Make catalog lists render their first page during SSR so the server-rendered HTML already contains the items, eliminating the large layout shift that previously happened on hydration.

**Why:** the catalog's `displayedItems` was a plain ref filled only in `onMounted`, so SSR emitted an empty list and the client painted the items only after hydration, causing a visible CLS jump (and weaker SEO).

**What changed:**
- `displayedItems` is now a `computed` reading `itemsFetch.data` (resolved at SSR time) instead of a ref populated client-side; the first page lands in the server HTML.
- Switched the items fetch from `useFetch` to the project-standard `useLocalFetch` (uses `$localFetch`), consistent with every other fetch in the portal.
- "Load more" accumulation now lives in a dedicated `appendedItems` ref; the redundant `onMounted` refetch was removed (`useFetch` already fetches on SSR + SPA nav).
- Removed a stale comment header in `sd-resources.ts` (referenced CSP logic the file no longer contains).

**Regression risks:**
- Removing the `onMounted` refetch means catalog pages no longer do a second client-side fetch of page 1 on mount — data now comes solely from the SSR payload. No consumer relied on that refresh, but it's the behavior change to sanity-check.
- `displayedItems` is now a read-only computed cast to `Ref<T[]>` to fit the existing interface; all consumers only read it, so the cast is safe.
- Worth a manual pass on infinite-scroll "load more" + paginated `goToPage` + filter/search reset, since the append/replace logic was rewritten. The `seo-indexing` e2e spec is the most relevant existing coverage.
