### PR TITLE
feat(portal): allow visitors to dismiss accented-text alerts

### DIFF
--- a/api/types/page-element-basics/schema.js
+++ b/api/types/page-element-basics/schema.js
@@ -123,8 +123,8 @@ export default {
       type: 'object',
       title: 'AlertElement',
       'x-i18n-title': {
-        en: 'Accented text',
-        fr: 'Texte accentué'
+        en: 'Accented text / Alert',
+        fr: 'Texte accentué / Alerte'
       },
       required: ['type', 'alertType'],
       layout: {
@@ -132,10 +132,10 @@ export default {
           {
             if: 'data?.alertType === "none"',
             children: [
-              'type', 'alertType', 'icon', 'color', 'title', 'content', 'mb'
+              'type', 'alertType', 'icon', 'color', 'title', 'content', 'closable', 'mb'
             ]
           },
-          ['type', 'alertType', 'title', 'content', 'mb']
+          ['type', 'alertType', 'title', 'content', 'closable', 'mb']
         ]
       },
       properties: {
@@ -172,6 +172,18 @@ export default {
           title: 'Contenu',
           type: 'string',
           layout: 'markdown'
+        },
+        closable: {
+          type: 'boolean',
+          title: 'Show a dismiss button',
+          'x-i18n-title': {
+            fr: 'Afficher un bouton de fermeture'
+          },
+          description: 'Visitors can dismiss the alert; the dismissal is saved in their browser so it is not shown to them again.',
+          'x-i18n-description': {
+            fr: "Les visiteurs peuvent fermer l'alerte; la fermeture est enregistrée dans leur navigateur pour ne pas la réafficher ensuite."
+          },
+          default: false
         },
         mb: { $ref: 'https://github.com/data-fair/portals/page-elements-defs#/$defs/margin-bottom' },
         _html: { $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/rendered-html' }

--- a/portal/app/components/page-element/basic/page-element-alert.vue
+++ b/portal/app/components/page-element/basic/page-element-alert.vue
@@ -1,9 +1,12 @@
 <template>
   <v-alert
+    v-if="visible"
     :type="element.alertType !== 'none' ? element.alertType : undefined"
     :title="element.title"
     :color="element.alertType === 'none' ? element.color : undefined"
+    :closable="closable"
     :class="element.mb !== 0 && `mb-${element.mb ?? 4}`"
+    @click:close="onClose"
   >
     <template
       v-if="element.alertType === 'none' && element.icon && (element.icon.mdi?.svgPath || element.icon.custom)"
@@ -27,4 +30,25 @@ import type { AlertElement } from '#api/types/page-elements/index.ts'
 const { element } = defineProps({
   element: { type: Object as () => AlertElement, required: true }
 })
+
+const { preview } = usePortalStore()
+
+// dismissals are persisted in a cookie shared with SSR, but never in the editor preview
+const dismissedAlerts = preview
+  ? null
+  : useCookie<string[] | undefined>('df_portal_dismissed_alerts', {
+    maxAge: 60 * 60 * 24 * 365, // 1 an
+    sameSite: true,
+    path: '/'
+  })
+
+const closable = computed(() => !!element.closable && !!element.uuid)
+const isDismissed = computed(() => !!element.uuid && !!dismissedAlerts?.value?.includes(element.uuid))
+const visible = computed(() => !(closable.value && isDismissed.value))
+
+const onClose = () => {
+  if (dismissedAlerts && element.uuid && !dismissedAlerts.value?.includes(element.uuid)) {
+    dismissedAlerts.value = [...(dismissedAlerts.value ?? []), element.uuid]
+  }
+}
 </script>

--- a/ui/src/components/page/page-preview-element.vue
+++ b/ui/src/components/page/page-preview-element.vue
@@ -28,7 +28,7 @@ defineProps<{ context: { isRoot: boolean, index: number, parentLength: number },
 
 const renderedElement = computed(() => {
   if (!element.value) return
-  if (element.value.type === 'text' && element.value.content) {
+  if ((element.value.type === 'text' || element.value.type === 'alert') && element.value.content) {
     return { ...element.value, _html: renderMarkdown(element.value.content ?? '') }
   }
   return element.value

--- a/ui/src/composables/nuxt-composables.ts
+++ b/ui/src/composables/nuxt-composables.ts
@@ -15,7 +15,7 @@ export function useRequestURL (): any {
   throw new Error('useRequestURL should only be called from portal, not portals-manager')
 }
 
-export function useCookie (_name: string, _options?: any): any {
+export function useCookie<T = any> (_name: string, _options?: any): Ref<T> {
   throw new Error('useCookie should only be called from portal, not portals-manager')
 }
 


### PR DESCRIPTION
Add a `closable` option to the "accented text / alert" page block (also relabeled `Texte accentué / Alerte`). When enabled, visitors get a close button and the dismissal is stored in a shared cookie (`df_portal_dismissed_alerts`, 1 year) so the alert is hidden from SSR onward — no flash before hydration. In the editor preview the alert is still closable but the dismissal is **not** persisted (it reappears on reload). Also fixes the editor's live markdown preview for alert blocks (previously only `text` blocks recomputed `_html` as you type).

**Why:** give portal admins an option to let visitors dismiss an alert, persisted in a cookie shared with the server so SSR doesn't render an already-dismissed alert (avoiding hydration clipping); deliberately non-persistent in the editor preview.

**Regression risks:**
- The alert's root `v-alert` is now under `v-if="visible"`; `closable:false` (default) keeps it always visible, so existing alerts are unchanged.
- Alert markdown is now recomputed client-side in the editor preview (same shared markdown lib as the server) — editor-only, production unchanged.
- New `df_portal_dismissed_alerts` cookie mirrors the existing `df_portal_track` settings (1 yr, sameSite, no secure).
