### PR TITLE
feat(ui): improve the domain exposure management page

### DIFF
--- a/api/types/portal-ingress/schema.js
+++ b/api/types/portal-ingress/schema.js
@@ -12,6 +12,8 @@ export default {
     url: {
       type: 'string',
       title: 'URL',
+      pattern: '^https?://[^/]+$',
+      errorMessage: "L'URL doit être de la forme https://exemple.com (protocole + domaine, sans chemin ni `/` final).",
       layout: {
         placeholder: 'https://test.com'
       }
@@ -20,6 +22,7 @@ export default {
       type: 'string',
       title: 'Certificat custom',
       layout: {
+        if: 'parent.data?.controller !== "manual"',
         placeholder: 'Laissez vide pour utiliser un certificat auto-géré'
       }
     },
@@ -34,6 +37,7 @@ export default {
     redirects: {
       type: 'array',
       title: 'Redirections spécifiques (résolues par le navigateur)',
+      layout: { if: 'parent.data?.controller !== "manual"' },
       items: {
         type: 'array',
         minItems: 2,
@@ -47,6 +51,7 @@ export default {
     rewrites: {
       type: 'array',
       title: 'Re-écriture (résolues directement sur le serveur)',
+      layout: { if: 'parent.data?.controller !== "manual"' },
       items: {
         type: 'array',
         minItems: 2,
@@ -60,6 +65,7 @@ export default {
     blockedIps: {
       type: 'array',
       title: 'IPs bloquées',
+      layout: { if: 'parent.data?.controller !== "manual"' },
       items: {
         type: 'string'
       }

--- a/ui/src/pages/portals/[id]/ingress.vue
+++ b/ui/src/pages/portals/[id]/ingress.vue
@@ -17,6 +17,7 @@
         <v-btn
           color="primary"
           :disabled="!formValid"
+          :loading="saveIngress.loading.value"
           @click="saveIngress.execute()"
         >
           {{ t('save') }}
@@ -43,7 +44,7 @@ watch(portalFetch.data, () => {
 const saveIngress = useAsyncAction(async () => {
   await $fetch(`/portals/${route.params.id}/ingress`, { method: 'POST', body: editIngress.value })
   await portalFetch.refresh()
-})
+}, { success: t('saved') })
 
 watch(portalFetch.data, (portal) => {
   if (!portal) return
@@ -76,10 +77,12 @@ const vjsfOptions = computed<VjsfOptions>(() => ({
     manageDomainExposure: Manage domain exposure
     portals: Portals
     save: Save
+    saved: Exposure saved
 
   fr:
     manageDomainExposure: Gérer l'exposition sur un domaine
     portals: Portails
     save: Enregistrer
+    saved: Exposition enregistrée
 
 </i18n>


### PR DESCRIPTION
Improve the domain exposure management page (`/portals/:id/ingress`):
- tighten the `url` validation to `^https?://[^/]+$` (no trailing slash, no path) so it matches the request origin used for portal lookup (`get-portal.ts`) and the dataset/application link templates (`service.ts`)
- hide `customerCert`, `redirects`, `rewrites` and `blockedIps` when the controller is `manual`, since the production ingress is then hand-managed and these fields are never applied
- show a success notification and a loading state on the save button via `useAsyncAction`

Regression notes:
- existing ingress records whose `url` has a trailing slash or a path now fail validation when the form is edited (no data migration, only blocks re-saving until corrected)
- switching a portal to the `manual` controller may drop the now-hidden redirect/rewrite/blockedIp/cert values on save, since VJSF strips hidden-field data
