### PR TITLE
fix(portal): prevent breadcrumb clipping in full-layout app bar on small screens

### DIFF
--- a/portal/app/components/layout/layout-breadcrumbs.vue
+++ b/portal/app/components/layout/layout-breadcrumbs.vue
@@ -8,6 +8,7 @@
   -->
   <component
     :is="isLayoutFull ? 'div' : VContainer"
+    :class="isLayoutFull ? 'd-none d-sm-block' : undefined"
     v-bind="isLayoutFull ? undefined : {
       class: 'pa-0',
       fluid: breadcrumbConfig.fluid,
@@ -17,7 +18,7 @@
       <v-breadcrumbs
         tag="ol"
         density="compact"
-        :class="{ 'px-0 ml-n1': isElement }"
+        :class="{ 'px-0 ml-n1': isElement, 'layout-full-breadcrumbs': isLayoutFull }"
       >
         <template
           v-for="(item, index) in breadcrumbItems"
@@ -109,21 +110,35 @@ const breadcrumbItems = computed(() => {
 <style scoped>
 
 :deep(.v-breadcrumbs-item--link:not([aria-current="page"])) {
-  background-image: linear-gradient(currentColor, currentColor);
-  background-position: 0 90%;
-  background-repeat: no-repeat;
-  background-size: 100% 1px;
-  text-decoration: none;
-  display: inline-block;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
 }
 
 :deep(.v-breadcrumbs-item--link:not([aria-current="page"]):hover),
 :deep(.v-breadcrumbs-item--link:not([aria-current="page"]):active) {
-  background-size: 100% 2px;
+  text-decoration-thickness: 2px;
 }
 
 :deep(.v-breadcrumbs-divider) {
   pointer-events: none;
   user-select: none;
+}
+
+/*
+  In the full layout the breadcrumbs live inside a fixed-height (64px) app bar whose content
+  is clipped (overflow: hidden). Without constraints a long title wraps to many lines and gets
+  cut off vertically. We cap each item to 2 lines with an ellipsis. `min-width: min-content`
+  keeps single-word items (e.g. "Datasets", "Table") at their natural width so only the long
+  items shrink and wrap — no hard-coded width, fully responsive.
+*/
+.layout-full-breadcrumbs :deep(.v-breadcrumbs-item),
+.layout-full-breadcrumbs :deep(.v-breadcrumbs-item--link) {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-width: min-content;
 }
 </style>

--- a/portal/app/components/layout/layout-full-app-bar.vue
+++ b/portal/app/components/layout/layout-full-app-bar.vue
@@ -4,25 +4,20 @@
     :color="portalConfig.navBar.color"
     flat
   >
-    <v-container
-      class="mx-2"
-      fluid
-    >
-      <v-row class="align-center">
-        <!-- Logo -->
-        <layout-header-logo
-          v-if="portalConfig.logo"
-          :height="(appBarHeight || 64) - 10"
-          :logo="portalConfig.logo"
-        />
+    <!-- Logo -->
+    <layout-header-logo
+      v-if="portalConfig.logo"
+      :height="(appBarHeight || 64) - 10"
+      :logo="portalConfig.logo"
+    />
 
-        <!-- Breadcrumbs -->
-        <v-spacer />
-        <LayoutBreadcrumbs is-layout-full/>
-        <v-spacer />
-        <div id="agent-chat-appbar" class="d-flex align-center" />
-      </v-row>
-    </v-container>
+    <!-- Breadcrumbs -->
+    <v-spacer />
+    <LayoutBreadcrumbs is-layout-full/>
+    <v-spacer />
+
+    <!-- Agent Chat -->
+    <div id="agent-chat-appbar" class="d-flex align-center" />
   </v-app-bar>
 </template>
 


### PR DESCRIPTION
Fix breadcrumb clipping in the full-layout app bar on small screens, where a long title would wrap and get cut off vertically inside the fixed-height (64px) app bar.

**Why:** in the full layout the breadcrumbs sit in an `overflow: hidden` 64px app bar; long titles wrapped to several lines and were clipped.

Changes:
- Cap each breadcrumb item to 2 lines with an ellipsis (`min-width: min-content` keeps short items at natural width, no hard-coded widths).
- Hide breadcrumbs on `xs` screens in the full layout (`d-none d-sm-block`).
- Replace the gradient-background underline on breadcrumb links with a real `text-decoration: underline` so it follows wrapped text instead of trailing across the whole box.
- Flatten the full app-bar markup, dropping the `v-container`/`v-row` wrapper.

**Regression risks:**
- Breadcrumbs are now fully hidden below the `sm` breakpoint in the full layout (no breadcrumb navigation on xs).
- Removing the `v-container.mx-2`/`v-row` wrapper changes logo + breadcrumb horizontal padding/alignment in the full app bar.
- The underline change is global to all breadcrumb links (both layouts), not just the full layout.
