### PR TITLE
feat(page-element): configurable display modes for application element

### DIFF
--- a/api/types/page-element-applications/schema.js
+++ b/api/types/page-element-applications/schema.js
@@ -281,9 +281,45 @@ export default {
             }
           }
         },
+        displayMode: {
+          type: 'string',
+          title: "Mode d'affichage",
+          default: 'auto-resize',
+          description: [
+            'Mode de redimensionnement de la visualisation :',
+            "- **Hauteur optimale** - La visualisation peut se redimensionner pour prendre la hauteur dont elle a besoin. Certaines visualisations comme des cartes se comporteront comme le mode **Hauteur optimale avec scroll**. Ce mode évite d'avoir une barre de scroll pour les visualisations qui prennent beaucoup de hauteur.",
+            "- **Hauteur optimale avec scroll** - Hauteur optimisée pour avoir le meilleur ratio largeur / hauteur sur toutes tailles d'écran.",
+            "- **Hauteur fixe (px)** - Vous définissez vous-même la hauteur de la visualisation, peu recommandé pour un affichage sur toute taille d'écran."
+          ].join('\n'),
+          oneOf: [
+            { const: 'auto-resize', title: 'Hauteur optimale' },
+            { const: 'aspect-ratio', title: 'Hauteur optimale avec scroll' },
+            { const: 'fixed-height', title: 'Hauteur fixe (px)' }
+          ]
+        },
+        height: {
+          type: 'integer',
+          title: 'Hauteur (px)',
+          default: 500,
+          minimum: 150,
+          layout: {
+            if: 'parent.data?.displayMode === "fixed-height"',
+            slots: {
+              after: {
+                markdown: "**⚠️ Attention :** une hauteur fixe est déconseillée. Sur les petites résolutions (mobiles, tablettes), l'affichage peut être difficile. Préférez « Hauteur optimale » ou « Hauteur optimale avec scroll » pour un rendu responsive."
+              }
+            }
+          }
+        },
         syncParams: {
           type: 'string',
           title: "Synchronisation des paramètres d'URL",
+          description: [
+            "Synchronisation des paramètres d'URL entre la visualisation et la page :",
+            "- **Aucune synchronisation** - Les filtres et paramètres de la visualisation ne sont pas reflétés dans l'URL de la page.",
+            "- **Synchronisation cloisonnée** - Les paramètres de la visualisation sont conservés dans l'URL avec un préfixe propre à ce bloc, sans interférer avec les autres visualisations de la page.",
+            '- **Synchronisation avec partage des filtres** - La visualisation partage les filtres (concepts `_c` et jeux de données `_d`) avec les autres blocs de la page.'
+          ].join('\n'),
           default: 'none',
           oneOf: [
             { const: 'none', title: 'Aucune synchronisation' },
@@ -299,7 +335,6 @@ export default {
             items: {
               type: 'array',
               title: 'Boutons à afficher',
-              description: 'Boutons d\'action à afficher au-dessus de la visualisation.',
               items: {
                 type: 'string',
                 oneOf: [

--- a/portal/app/components/application/application-actions.vue
+++ b/portal/app/components/application/application-actions.vue
@@ -3,6 +3,7 @@
     :justify="alignment"
     no-gutters
     class="ga-1"
+    :style="preview ? 'pointer-events: none' : undefined"
   >
     <action-btn
       v-if="showAction('fullscreen')"

--- a/portal/app/components/page-element/applications/page-element-application.vue
+++ b/portal/app/components/page-element/applications/page-element-application.vue
@@ -17,6 +17,8 @@
       :src="`${application.href}/capture?updatedAt=${application.updatedAt}`"
       :title="t('previewTooltip')"
       :alt="application.title"
+      :height="displayMode === 'fixed-height' ? fixedHeight : undefined"
+      :cover="displayMode === 'fixed-height'"
     />
 
     <d-frame-wrapper
@@ -24,7 +26,9 @@
       :iframe-title="`${t('application')} - ${element.application.title}`"
       :src="'/data-fair/app/' + element.application.slug + `?d-frame=true&primary=${$vuetify.theme.current.colors.primary}`"
       :sync-params="syncParams"
-      aspect-ratio
+      :aspect-ratio="displayMode !== 'fixed-height' ? '' : undefined"
+      :height="displayMode === 'fixed-height' ? fixedHeight + 'px' : undefined"
+      :resize="displayMode === 'auto-resize' ? undefined : 'no'"
     />
 
     <application-actions
@@ -63,6 +67,9 @@ const syncParams = computed(() => {
 })
 
 const hasActions = computed(() => (element.actionButtons?.items ?? []).length > 0)
+
+const displayMode = computed(() => element.displayMode ?? 'auto-resize')
+const fixedHeight = computed(() => element.height ?? 500)
 
 const applicationFetcher = preview ? useFetch<Application> : useLocalFetch<Application>
 const applicationFetch = applicationFetcher(() => element.application?.id ? '/data-fair/api/v1/applications/' + element.application.id : '')


### PR DESCRIPTION
- Ajoute un mode d'affichage configurable à la visualisation du page-element Application : **Hauteur optimale** (défaut, comportement actuel), **Hauteur optimale avec scroll** et **Hauteur fixe (px)**
- Le mode pilote les attributs `aspect-ratio` / `height` / `resize` de la `d-frame`
- Ajoute une description markdown détaillée au sélecteur de mode et au champ « Synchronisation des paramètres d'URL »
- Rend les boutons d'action inertes (`pointer-events: none`) en mode preview de l'éditeur : plus de navigation, dialog ni `window.open`
- Défaut `auto-resize` = aucune régression sur les visualisations existantes
