### PR TITLE
feat(portal): hand the agent ready-made absolute links for navigation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
       "NotebookEdit",
       "WebFetch",
       "WebSearch",
-      "mcp__*"
+      "mcp__playwright-test"
     ],
     "deny": []
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -958,9 +958,9 @@
       }
     },
     "node_modules/@data-fair/agent-tools-data-fair": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@data-fair/agent-tools-data-fair/-/agent-tools-data-fair-0.6.0.tgz",
-      "integrity": "sha512-WXbs0SzccZU0WxmQmzCfj/xHtdWj0Rg0d3jkjFX1Z+MP3YFNx5GuM4tzWs6aEkgQdQnCAjwZ7VnRUARXWfl3lA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@data-fair/agent-tools-data-fair/-/agent-tools-data-fair-0.6.1.tgz",
+      "integrity": "sha512-1DDJ0kInn8Flhbqz+BCFr2B/7kSTnlHc1DQ/Ta4QUphN5iia98564n7DVHAaQpwVYsFI0G7gwbRiiDgfka1EnA==",
       "license": "AGPL-3.0-only"
     },
     "node_modules/@data-fair/frame": {
@@ -24442,7 +24442,7 @@
       "dependencies": {
         "@analytics/google-analytics": "^1.1.0",
         "@analytics/google-tag-manager": "^0.6.0",
-        "@data-fair/agent-tools-data-fair": "^0.6.0",
+        "@data-fair/agent-tools-data-fair": "^0.6.1",
         "@data-fair/frame": "^0.18.1",
         "@data-fair/lib-common-types": "^1.20.2",
         "@data-fair/lib-node": "^2.12.1",

--- a/portal/app/composables/agent/navigation-tools.ts
+++ b/portal/app/composables/agent/navigation-tools.ts
@@ -7,6 +7,7 @@ import { useAgentTool } from '@data-fair/lib-vue-agents'
 import { useReactiveSearchParams } from '@data-fair/lib-vue/reactive-search-params.js'
 import { unwrapFilterQuery } from '@data-fair/agent-tools-data-fair/_utils'
 import { createAgentTranslator } from './utils'
+import { toAbsoluteUrl, toRoutePath } from './url-utils'
 
 type BreadcrumbItems = NonNullable<VBreadcrumbs['$props']['items']>
 
@@ -48,9 +49,15 @@ export function useAgentNavigationTools ({ locale, portalConfig, navigationStore
   const route = useRoute()
   const router = useRouter()
 
+  // Absolute portal URL for a router path (or {slug} template). The router history
+  // base carries the deployment path prefix (e.g. /portal/) — the same base the host
+  // (useAgentChatBase) checks before doing an SPA router.push, so emitting links built
+  // from it lets clicked prose links navigate without a full page reload.
+  const appUrl = (path: string) => toAbsoluteUrl(window.location.origin, router.options.history.base, path)
+
   useAgentTool({
     name: 'get_current_location',
-    description: 'Get the current page location in the portal, including route path, name, parameters, query, and breadcrumbs.',
+    description: 'Get the current page location in the portal, including its full URL, route path, name, parameters, query, and breadcrumbs.',
     annotations: { title: t('getCurrentLocation'), readOnlyHint: true },
     inputSchema: {
       type: 'object' as const,
@@ -61,14 +68,19 @@ export function useAgentNavigationTools ({ locale, portalConfig, navigationStore
         .map(b => {
           if (typeof b === 'string') return `- ${b}`
           const title = b.title || ''
-          const path = b.to ? (typeof b.to === 'string' ? b.to : router.resolve(b.to).href) : b.href || ''
+          // router.resolve().href already includes the history base, so only prepend the
+          // origin; a bare string `to` is a base-less router path → use appUrl; b.href is
+          // an already-absolute external URL → keep verbatim.
+          const path = b.to
+            ? (typeof b.to === 'string' ? appUrl(b.to) : window.location.origin + router.resolve(b.to).href)
+            : b.href || ''
           return `- ${title}: ${path}`
         })
         .join('\n')
       return {
         content: [{
           type: 'text' as const,
-          text: `**Path**: ${route.path}\n**Name**: ${route.name as string}\n**Params**: ${JSON.stringify({ ...route.params })}\n**Query**: ${JSON.stringify({ ...route.query })}\n**Breadcrumbs**:\n${breadcrumbs}`
+          text: `**URL**: ${appUrl(route.fullPath)}\n**Path**: ${route.path}\n**Name**: ${route.name as string}\n**Params**: ${JSON.stringify({ ...route.params })}\n**Query**: ${JSON.stringify({ ...route.query })}\n**Breadcrumbs**:\n${breadcrumbs}`
         }]
       }
     }
@@ -76,7 +88,7 @@ export function useAgentNavigationTools ({ locale, portalConfig, navigationStore
 
   useAgentTool({
     name: 'list_pages',
-    description: 'List all available pages in the portal navigation menu, plus detail page patterns for datasets, applications, events, news, and reuses.',
+    description: 'List all available pages in the portal navigation menu, plus detail page patterns for datasets, applications, events, news, and reuses. Returns full absolute URLs — use them verbatim when writing links; substitute {slug} and append `?<query>` for filtered views, but never alter the origin or path prefix.',
     annotations: { title: t('listPages'), readOnlyHint: true },
     inputSchema: {
       type: 'object' as const,
@@ -100,7 +112,7 @@ export function useAgentNavigationTools ({ locale, portalConfig, navigationStore
             const title = navigationStore.resolveLinkTitle(item, localeVal)
             const path = navigationStore.resolveLink(item)
             if (path && item.type !== 'external') {
-              lines.push(`${indent}- ${title}: ${path}`)
+              lines.push(`${indent}- ${title}: ${appUrl(path)}`)
             } else if (path && item.type === 'external') {
               lines.push(`${indent}- ${title}: ${path} (external)`)
             }
@@ -115,25 +127,25 @@ export function useAgentNavigationTools ({ locale, portalConfig, navigationStore
       }
 
       sections.push(
-        '**Detail pages** (use list_datasets, list_applications, list_events, list_news, or list_reuses to find slugs). The {slug} placeholders below are the human-readable slug returned by those tools; for datasets and applications fall back to the `id` only when no slug exists:\n' +
-        '- Dataset detail: /datasets/{slug}\n' +
-        '- Dataset table: /datasets/{slug}/table — accepts a filter query string. Use the filterQuery from the dataset_data subagent Context directly as the query parameter; do not build or edit the parameters yourself.\n' +
-        '- Dataset map: /datasets/{slug}/map — for geolocalized datasets, accepts the same filterQuery as the table page\n' +
-        '- Dataset API doc: /datasets/{slug}/api-doc\n' +
-        '- Application detail: /applications/{slug}\n' +
-        '- Application full view: /applications/{slug}/full\n' +
-        '- Event detail: /event/{slug}\n' +
-        '- News detail: /news/{slug}\n' +
-        '- Reuse detail: /reuses/{slug}'
+        '**Detail pages** (use list_datasets, list_applications, list_events, list_news, or list_reuses to find slugs). The {slug} placeholders below are the human-readable slug returned by those tools; for datasets and applications fall back to the `id` only when no slug exists. The URLs are absolute — substitute {slug} and append `?<query>`, but keep the origin and path prefix:\n' +
+        `- Dataset detail: ${appUrl('/datasets/{slug}')}\n` +
+        `- Dataset table: ${appUrl('/datasets/{slug}/table')} — accepts a filter query string. Use the filterQuery from the dataset_data subagent Context directly as the query parameter; do not build or edit the parameters yourself.\n` +
+        `- Dataset map: ${appUrl('/datasets/{slug}/map')} — for geolocalized datasets, accepts the same filterQuery as the table page\n` +
+        `- Dataset API doc: ${appUrl('/datasets/{slug}/api-doc')}\n` +
+        `- Application detail: ${appUrl('/applications/{slug}')}\n` +
+        `- Application full view: ${appUrl('/applications/{slug}/full')}\n` +
+        `- Event detail: ${appUrl('/event/{slug}')}\n` +
+        `- News detail: ${appUrl('/news/{slug}')}\n` +
+        `- Reuse detail: ${appUrl('/reuses/{slug}')}`
       )
 
       sections.push(
         '**User pages**:\n' +
-        '- My account: /me\n' +
-        '- My reuses: /me/reuses\n' +
-        '- Update dataset: /me/update-dataset\n' +
-        '- My processings: /me/processings\n' +
-        '- My notifications: /me/notifications'
+        `- My account: ${appUrl('/me')}\n` +
+        `- My reuses: ${appUrl('/me/reuses')}\n` +
+        `- Update dataset: ${appUrl('/me/update-dataset')}\n` +
+        `- My processings: ${appUrl('/me/processings')}\n` +
+        `- My notifications: ${appUrl('/me/notifications')}`
       )
 
       return {
@@ -147,14 +159,14 @@ export function useAgentNavigationTools ({ locale, portalConfig, navigationStore
 
   useAgentTool({
     name: 'navigate',
-    description: 'Navigate to a page in the portal. Use list_pages to discover available paths, and list_datasets, list_applications, list_events, list_news, or list_reuses to find resource slugs/refs — prefer the human-readable `slug` over the `id` when building dataset and application paths. Optionally pass query parameters. IMPORTANT: when you search or filter data from a dataset, offer to navigate the user to the filtered table view at /datasets/{slug}/table by passing the same filter parameters as query params — but only when the search returned results (totalResults > 0).',
+    description: 'Navigate to a page in the portal. Accepts either a full absolute URL (as returned by list_pages or get_current_location) or a bare path — both work. Use list_datasets, list_applications, list_events, list_news, or list_reuses to find resource slugs/refs — prefer the human-readable `slug` over the `id` when building dataset and application paths. Optionally pass query parameters. IMPORTANT: when you search or filter data from a dataset, offer to navigate the user to the filtered table view at /datasets/{slug}/table by passing the same filter parameters as query params — but only when the search returned results (totalResults > 0).',
     annotations: { title: t('navigateToPage') },
     inputSchema: {
       type: 'object' as const,
       properties: {
         path: {
           type: 'string' as const,
-          description: 'The path to navigate to (e.g. "/datasets", "/datasets/my-dataset", "/event/my-event")'
+          description: 'The destination, either a full absolute URL (e.g. as returned by list_pages) or a path (e.g. "/datasets", "/datasets/my-dataset", "/event/my-event"). Both are accepted.'
         },
         query: {
           type: 'string' as const,
@@ -165,11 +177,13 @@ export function useAgentNavigationTools ({ locale, portalConfig, navigationStore
     },
     execute: async (params) => {
       try {
+        // Accept a full absolute URL, a base-prefixed path, or a bare router path.
+        const { path, query: embeddedQuery } = toRoutePath(window.location.origin, router.options.history.base, params.path)
         // Defensive unwrap: the agent is told to pass the dataset_data subagent's filterQuery
         // value directly, but it sometimes wraps it as "filterQuery=<the whole query string>".
-        const queryString = unwrapFilterQuery(params.query as string | undefined)
+        const queryString = unwrapFilterQuery(params.query as string | undefined) || embeddedQuery
         const query = queryString ? Object.fromEntries(new URLSearchParams(queryString)) : undefined
-        await router.push(query ? { path: params.path, query } : params.path)
+        await router.push(query ? { path, query } : path)
         await new Promise(resolve => setTimeout(resolve, 500))
         const currentRoute = router.currentRoute.value
         return {

--- a/portal/app/composables/agent/portal-prompt-context.ts
+++ b/portal/app/composables/agent/portal-prompt-context.ts
@@ -25,7 +25,7 @@ export function portalPromptContext (portalConfig: PortalConfig, ownerName?: str
 
   const origin = import.meta.client ? window.location.origin : ''
   if (origin) {
-    parts.push(`Présente toujours les liens vers les pages du portail comme des liens markdown avec une URL absolue, par exemple \`[Voir la carte](${origin}/datasets/mon-jeu/map)\` — jamais un chemin relatif ni une URL brute non formatée.`)
+    parts.push('Présente toujours les liens vers les pages du portail comme des liens markdown en reprenant telle quelle l\'URL absolue fournie par les outils (list_pages, get_current_location, et le champ `Link` des jeux de données), par exemple `[Voir la carte](<URL absolue du jeu>/map?<filterQuery>)`. N\'écris jamais un chemin relatif, ni une URL brute non formatée, ni une URL assemblée à la main : modifie uniquement le placeholder {slug} et la query, sans toucher à l\'origine ni au préfixe de chemin.')
   }
   return parts
 }

--- a/portal/app/composables/agent/url-utils.ts
+++ b/portal/app/composables/agent/url-utils.ts
@@ -1,0 +1,37 @@
+// Pure helpers for turning agent-facing links into absolute portal URLs and back
+// into router paths. Kept free of Vue/router/window so they can be unit-tested.
+//
+// Why this exists: the agent chat renders prose in the agents iframe and the iframe
+// resolves clicked links against its own URL, so links must be full absolute URLs
+// (origin + history base + path) to survive the round-trip to the host portal. The
+// host (useAgentChatBase) only does an SPA router.push when a clicked link's pathname
+// starts with the router history base — otherwise it full-reloads window.location. The
+// agent is therefore handed ready-made absolute URLs (list_pages, get_current_location);
+// `navigate` accepts those same absolute URLs (or a bare path) and reduces them back to
+// a base-less router path for router.push.
+
+/** Strip a trailing slash from a router history base: '/portal/' -> '/portal', '/' -> ''. */
+const normalizeBase = (base: string): string => (base.endsWith('/') ? base.slice(0, -1) : base)
+
+/**
+ * Build an absolute portal URL from a router path. The path may be a template still
+ * containing placeholders (e.g. `/datasets/{slug}`), so no URL parsing is done here.
+ */
+export function toAbsoluteUrl (origin: string, base: string, path: string): string {
+  return origin + normalizeBase(base) + (path.startsWith('/') ? path : '/' + path)
+}
+
+/**
+ * Reduce any link the agent produced — a full URL, a base-prefixed path, or a bare
+ * router path — to a base-less router path plus any embedded query string. Robust to a
+ * wrong/hallucinated origin: only the pathname (and query) of the input is used.
+ */
+export function toRoutePath (origin: string, base: string, input: string): { path: string, query?: string } {
+  const parsed = new URL(input, origin)
+  const baseNoTrailing = normalizeBase(base)
+  let pathname = parsed.pathname
+  if (baseNoTrailing && (pathname === baseNoTrailing || pathname.startsWith(baseNoTrailing + '/'))) {
+    pathname = pathname.slice(baseNoTrailing.length) || '/'
+  }
+  return { path: pathname, query: parsed.search ? parsed.search.slice(1) : undefined }
+}

--- a/portal/package.json
+++ b/portal/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@analytics/google-analytics": "^1.1.0",
     "@analytics/google-tag-manager": "^0.6.0",
-    "@data-fair/agent-tools-data-fair": "^0.6.0",
+    "@data-fair/agent-tools-data-fair": "^0.6.1",
     "@data-fair/frame": "^0.18.1",
     "@data-fair/lib-common-types": "^1.20.2",
     "@data-fair/lib-node": "^2.12.1",

--- a/tests/features/agent-tools/url-utils.unit.spec.ts
+++ b/tests/features/agent-tools/url-utils.unit.spec.ts
@@ -1,0 +1,52 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { toAbsoluteUrl, toRoutePath } from '../../../portal/app/composables/agent/url-utils.ts'
+
+const ORIGIN = 'https://portal.example.com'
+
+test.describe('toAbsoluteUrl', () => {
+  test('prefixes origin to a router path when base is root', () => {
+    assert.equal(toAbsoluteUrl(ORIGIN, '/', '/datasets/my-dataset/table'), 'https://portal.example.com/datasets/my-dataset/table')
+  })
+
+  test('prefixes origin + base to a router path', () => {
+    assert.equal(toAbsoluteUrl(ORIGIN, '/portal/', '/datasets/abc/map'), 'https://portal.example.com/portal/datasets/abc/map')
+  })
+
+  test('keeps {slug} templates intact (no URL parsing/encoding)', () => {
+    assert.equal(toAbsoluteUrl(ORIGIN, '/', '/datasets/{slug}'), 'https://portal.example.com/datasets/{slug}')
+  })
+
+  test('adds a missing leading slash to the path', () => {
+    assert.equal(toAbsoluteUrl(ORIGIN, '/', 'datasets'), 'https://portal.example.com/datasets')
+  })
+})
+
+test.describe('toRoutePath', () => {
+  test('strips origin from a full absolute URL (root base)', () => {
+    assert.deepEqual(toRoutePath(ORIGIN, '/', 'https://portal.example.com/datasets/abc/table'), { path: '/datasets/abc/table', query: undefined })
+  })
+
+  test('preserves the embedded query string', () => {
+    assert.deepEqual(
+      toRoutePath(ORIGIN, '/', 'https://portal.example.com/datasets/abc/table?ville_eq=Paris&_c_q=foo'),
+      { path: '/datasets/abc/table', query: 'ville_eq=Paris&_c_q=foo' }
+    )
+  })
+
+  test('strips the base from a base-prefixed path', () => {
+    assert.deepEqual(toRoutePath(ORIGIN, '/portal/', '/portal/datasets/abc'), { path: '/datasets/abc', query: undefined })
+  })
+
+  test('leaves a bare base-less router path unchanged (backward compat)', () => {
+    assert.deepEqual(toRoutePath(ORIGIN, '/portal/', '/datasets/abc'), { path: '/datasets/abc', query: undefined })
+  })
+
+  test('recovers the path from a wrong/hallucinated origin', () => {
+    assert.deepEqual(toRoutePath(ORIGIN, '/', 'https://wrong.example.org/datasets/abc'), { path: '/datasets/abc', query: undefined })
+  })
+
+  test('maps the base root to "/"', () => {
+    assert.deepEqual(toRoutePath(ORIGIN, '/portal/', 'https://portal.example.com/portal'), { path: '/', query: undefined })
+  })
+})


### PR DESCRIPTION
Port the data-fair absolute-links fix (#433) to the portal's agent integration so the chat assistant emits links that actually work.

**Why:** the agent chat renders prose inside an iframe that resolves a clicked relative link against its *own* URL, dropping the deployment path prefix and full-reloading the host to a 404. Models also resist hand-assembling paths and hallucinate origins. The fix hands the model ready-made absolute URLs and tells it to use them verbatim.

**What changed:**
- New pure, unit-tested helpers `toAbsoluteUrl` / `toRoutePath` (`portal/app/composables/agent/url-utils.ts`).
- `list_pages` and `get_current_location` now emit absolute URLs (`origin` + router history base + path); breadcrumbs and the current location gain a full `URL`.
- `navigate` accepts either a full absolute URL or a bare path, reducing it back to a router path (and picking up any embedded query) before `router.push`.
- System prompt now tells the model to reuse the tool-provided absolute URLs verbatim instead of building `origin + path` itself.
- Bumped `@data-fair/agent-tools-data-fair` `^0.6.0 → ^0.6.1` for the per-dataset `Link:` line, which defaults to the public portal `page` — the correct link for the portal (no `datasetLink` override needed).

**Regression risks:**
- `navigate` now always normalizes its `path` input through `toRoutePath` (strips origin + history base, extracts an embedded query) rather than passing the raw string to `router.push`. Equivalent for bare/base-prefixed paths and an improvement for full URLs, but **`toRoutePath` drops any `#hash`** — confirm no agent navigation target relies on a fragment.
- The agent-tools `^0.6.1` bump changes `list_datasets`/`describe_dataset` text output (adds a `Link:` line). Intended, but it alters the text the model receives.
- Absolute-URL emission keys off `router.options.history.base`; correct for sub-path deployments only if that base matches the host's. It's the same base `useAgentChatBase` checks, so they stay in sync.
