### PR TITLE
fix(portal): trim edge margins on rendered markdown paragraphs

### DIFF
--- a/shared/markdown/style.css
+++ b/shared/markdown/style.css
@@ -1,3 +1,14 @@
+.markdown-paragraph:first-child {
+  margin-top: 0 !important;
+}
+.markdown-paragraph:last-child {
+  margin-bottom: 0 !important;
+}
+
+/* 
+ * Compat: stored _html rendered before lib-utils 1.10 has no mt-4/mb-4 on <p>;
+ * keep this so old content still gets spacing between paragraphs.
+ */
 .markdown-paragraph:not(:last-child) {
   margin-bottom: 16px;
 }


### PR DESCRIPTION
Rendered markdown paragraphs showed unwanted top/bottom margins on the first and last element of a block (e.g. a single line of accented text in a `v-alert` had a margin above and below).

**Why:** `markedVuetify` (`@data-fair/lib-utils` 1.10, pulled in by the Vuetify 4 migration #40, shipped in v2.22.0) now bakes `mt-4 mb-4` onto every `<p>`, including the first and last, so the existing `:not(:last-child)` rule no longer trimmed the outer margins. Fix: zero the edge margins via `.markdown-paragraph:first-child`/`:last-child` (`!important` to beat the Vuetify utilities).

**Regression risks:**
- The `:not(:last-child)` rule is kept on purpose: `_html` is rendered once then stored, so content saved before lib-utils 1.10 has no `mt-4/mb-4` and still relies on it for inter-paragraph spacing. Removing it would collapse old multi-paragraph content.
- The stylesheet is shared by both the SSR portal and the UI page-editor preview, so the spacing applies to both (intended).
- Edge trimming targets paragraphs only; if a block starts/ends with a heading, list or table, that element keeps its own margin (unchanged).
