### PR TITLE
feat(page-element): add variant option (outlined/tonal) to alert element

### DIFF
--- a/api/types/page-element-basics/schema.js
+++ b/api/types/page-element-basics/schema.js
@@ -132,10 +132,10 @@ export default {
           {
             if: 'data?.alertType === "none"',
             children: [
-              'type', 'alertType', 'icon', 'color', 'title', 'content', 'closable', 'mb'
+              'type', 'alertType', 'icon', 'color', 'variant', 'title', 'content', 'closable', 'mb'
             ]
           },
-          ['type', 'alertType', 'title', 'content', 'closable', 'mb']
+          ['type', 'alertType', 'variant', 'title', 'content', 'closable', 'mb']
         ]
       },
       properties: {
@@ -163,6 +163,10 @@ export default {
               selection: { name: 'color-select-selection' }
             }
           }
+        },
+        variant: {
+          $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/variant',
+          default: 'default'
         },
         title: {
           title: 'Titre',

--- a/portal/app/components/page-element/basic/page-element-alert.vue
+++ b/portal/app/components/page-element/basic/page-element-alert.vue
@@ -4,6 +4,8 @@
     :type="element.alertType !== 'none' ? element.alertType : undefined"
     :title="element.title"
     :color="element.alertType === 'none' ? element.color : undefined"
+    :variant="element.variant && element.variant !== 'default' ? element.variant : undefined"
+    :border="element.variant === 'tonal' ? 'start' : undefined"
     :closable="closable"
     :class="element.mb !== 0 && `mb-${element.mb ?? 4}`"
     @click:close="onClose"


### PR DESCRIPTION
Add a `variant` option to the alert page-element, letting editors render alerts with the default coloured background, an outlined border, or a tonal style. The tonal variant also gets a start accent border. Reuses the shared `variant` $def from `common-defs` (default / outlined / tonal).

**Why:** give alert elements the same visual variants already available on other elements, for more flexible page styling.

**Regression risks:**
- Existing alerts have no `variant` field; the schema defaults it to `default` and the component maps `default`/undefined to no `:variant` prop, so existing alerts render exactly as before. Worth a glance to confirm.
- `.type/` generated types are gitignored — reviewers/CI must run `build-types` for `AlertElement.variant` to type-check.
