### PR TITLE
feat(ui): add sort field to pages, portals and reuses navigation drawers

### DIFF
--- a/api/src/pages/router.ts
+++ b/api/src/pages/router.ts
@@ -17,7 +17,7 @@ router.get('', async (req, res, next) => {
   assertAccountRole(session, session.account, 'admin')
 
   const params = req.query as Record<string, string>
-  const sort = findUtils.sort(params.sort || 'createdAt:-1')
+  const sort = params.q ? { _score: { $meta: 'textScore' } } : findUtils.sort(params.sort || 'createdAt:-1')
   const { skip, size } = findUtils.pagination(params)
   const project = findUtils.project(params.select)
   const filters = findUtils.query(params, { portal: 'portals', type: 'type', groupId: 'config.genericMetadata.group._id' })

--- a/ui/src/components/pages-actions.vue
+++ b/ui/src/components/pages-actions.vue
@@ -1,329 +1,310 @@
 <template>
-  <!-- Create new page -->
-  <custom-router-link :to="'/pages/new'">
-    <v-list-item link>
-      <template #prepend>
-        <v-icon
-          color="primary"
-          :icon="mdiPlusCircle"
-        />
+  <df-navigation-right>
+    <!-- Create new page -->
+    <custom-router-link :to="'/pages/new'">
+      <v-list-item link>
+        <template #prepend>
+          <v-icon
+            color="primary"
+            :icon="mdiPlusCircle"
+          />
+        </template>
+        {{ t('createNewPage') }}
+      </v-list-item>
+    </custom-router-link>
+
+    <!-- Create new group -->
+    <v-menu
+      v-model="newGroupMenu"
+      location="start"
+      :close-on-content-click="false"
+    >
+      <template #activator="{ props }">
+        <v-list-item v-bind="props">
+          <template #prepend>
+            <v-icon
+              color="primary"
+              :icon="mdiFolderPlusOutline"
+            />
+          </template>
+          {{ t('createNewGroup') }}
+        </v-list-item>
       </template>
-      {{ t('createNewPage') }}
-    </v-list-item>
-  </custom-router-link>
-
-  <!-- Create new group -->
-  <v-menu
-    v-model="newGroupMenu"
-    location="start"
-    :close-on-content-click="false"
-  >
-    <template #activator="{ props }">
-      <v-list-item v-bind="props">
-        <template #prepend>
-          <v-icon
-            color="primary"
-            :icon="mdiFolderPlusOutline"
+      <v-card
+        data-iframe-height
+        min-width="300"
+        rounded="lg"
+        :loading="createGroup.loading.value ? 'primary' : undefined"
+      >
+        <v-card-text>
+          <v-text-field
+            v-model="newGroupTitle"
+            :label="t('newGroupTitle')"
+            density="comfortable"
+            variant="outlined"
+            autofocus
+            auto-grow
+            hide-details
           />
-        </template>
-        {{ t('createNewGroup') }}
-      </v-list-item>
-    </template>
-    <v-card
-      data-iframe-height
-      min-width="300"
-      rounded="lg"
-      :loading="createGroup.loading.value ? 'primary' : undefined"
-    >
-      <v-card-text>
-        <v-text-field
-          v-model="newGroupTitle"
-          :label="t('newGroupTitle')"
-          density="comfortable"
-          variant="outlined"
-          autofocus
-          auto-grow
-          hide-details
-        />
-        <v-textarea
-          v-model="newGroupDescription"
-          :label="t('newGroupDescription')"
-          :rules="[rules.maxLength(100)]"
-          :counter="100"
-          class="mt-4"
-          density="comfortable"
-          hide-details="auto"
-          variant="outlined"
-          no-resize
-        />
-      </v-card-text>
-      <v-card-actions>
-        <v-spacer />
-        <v-btn
-          :disabled="createGroup.loading.value"
-          @click="newGroupMenu = false"
-        >
-          {{ t('cancel') }}
-        </v-btn>
-        <v-btn
-          color="primary"
-          variant="flat"
-          :disabled="!newGroupTitle || newGroupDescription.length > 100"
-          :loading="createGroup.loading.value ? 'primary' : false"
-          @click="createGroup.execute()"
-        >
-          {{ t('create') }}
-        </v-btn>
-      </v-card-actions>
-    </v-card>
-  </v-menu>
-
-  <!-- Group management menu -->
-  <v-menu
-    v-model="editGroupMenu"
-    location="start"
-    :close-on-content-click="false"
-  >
-    <template #activator="{ props }">
-      <v-list-item v-bind="props">
-        <template #prepend>
-          <v-icon
-            color="primary"
-            :icon="mdiPencil"
+          <v-textarea
+            v-model="newGroupDescription"
+            :label="t('newGroupDescription')"
+            :rules="[rules.maxLength(100)]"
+            :counter="100"
+            class="mt-4"
+            density="comfortable"
+            hide-details="auto"
+            variant="outlined"
+            no-resize
           />
-        </template>
-        {{ t('editGroup') }}
-      </v-list-item>
-    </template>
-    <v-card
-      data-iframe-height
-      min-width="300"
-      rounded="lg"
-      :loading="editGroup.loading.value ? 'primary' : undefined"
-    >
-      <v-card-text>
-        <v-select
-          v-model="editGroupId"
-          :items="editableGroups"
-          item-title="title"
-          item-value="_id"
-          :label="t('selectGroup')"
-          density="comfortable"
-          variant="outlined"
-          hide-details
-        />
-        <v-text-field
-          v-model="editGroupTitle"
-          :label="t('editGroupTitle')"
-          density="comfortable"
-          variant="outlined"
-          :disabled="!editGroupId"
-          class="mt-4"
-          auto-grow
-          hide-details
-        />
-        <v-textarea
-          v-model="editGroupDescription"
-          :label="t('editGroupDescription')"
-          :rules="[rules.maxLength(100)]"
-          :counter="100"
-          class="mt-4"
-          density="comfortable"
-          hide-details="auto"
-          variant="outlined"
-          no-resize
-          :disabled="!editGroupId"
-        />
-      </v-card-text>
-      <v-card-actions>
-        <v-spacer />
-        <v-btn
-          :disabled="editGroup.loading.value"
-          @click="editGroupMenu = false"
-        >
-          {{ t('cancel') }}
-        </v-btn>
-        <v-btn
-          color="primary"
-          variant="flat"
-          :disabled="!editGroupId || !editGroupTitle || editGroupDescription.length > 100"
-          :loading="editGroup.loading.value ? 'primary' : false"
-          @click="editGroup.execute()"
-        >
-          {{ t('save') }}
-        </v-btn>
-      </v-card-actions>
-    </v-card>
-  </v-menu>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            :disabled="createGroup.loading.value"
+            @click="newGroupMenu = false"
+          >
+            {{ t('cancel') }}
+          </v-btn>
+          <v-btn
+            color="primary"
+            variant="flat"
+            :disabled="!newGroupTitle || newGroupDescription.length > 100"
+            :loading="createGroup.loading.value ? 'primary' : false"
+            @click="createGroup.execute()"
+          >
+            {{ t('create') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-menu>
 
-  <!-- Delete group menu -->
-  <v-menu
-    v-model="deleteGroupMenu"
-    :close-on-content-click="false"
-    max-width="500"
-  >
-    <template #activator="{ props }">
-      <v-list-item v-bind="props">
-        <template #prepend>
-          <v-icon
+    <!-- Group management menu -->
+    <v-menu
+      v-model="editGroupMenu"
+      location="start"
+      :close-on-content-click="false"
+    >
+      <template #activator="{ props }">
+        <v-list-item v-bind="props">
+          <template #prepend>
+            <v-icon
+              color="primary"
+              :icon="mdiPencil"
+            />
+          </template>
+          {{ t('editGroup') }}
+        </v-list-item>
+      </template>
+      <v-card
+        data-iframe-height
+        min-width="300"
+        rounded="lg"
+        :loading="editGroup.loading.value ? 'primary' : undefined"
+      >
+        <v-card-text>
+          <v-select
+            v-model="editGroupId"
+            :items="editableGroups"
+            item-title="title"
+            item-value="_id"
+            :label="t('selectGroup')"
+            density="comfortable"
+            variant="outlined"
+            hide-details
+          />
+          <v-text-field
+            v-model="editGroupTitle"
+            :label="t('editGroupTitle')"
+            density="comfortable"
+            variant="outlined"
+            :disabled="!editGroupId"
+            class="mt-4"
+            auto-grow
+            hide-details
+          />
+          <v-textarea
+            v-model="editGroupDescription"
+            :label="t('editGroupDescription')"
+            :rules="[rules.maxLength(100)]"
+            :counter="100"
+            class="mt-4"
+            density="comfortable"
+            hide-details="auto"
+            variant="outlined"
+            no-resize
+            :disabled="!editGroupId"
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            :disabled="editGroup.loading.value"
+            @click="editGroupMenu = false"
+          >
+            {{ t('cancel') }}
+          </v-btn>
+          <v-btn
+            color="primary"
+            variant="flat"
+            :disabled="!editGroupId || !editGroupTitle || editGroupDescription.length > 100"
+            :loading="editGroup.loading.value ? 'primary' : false"
+            @click="editGroup.execute()"
+          >
+            {{ t('save') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-menu>
+
+    <!-- Delete group menu -->
+    <v-menu
+      v-model="deleteGroupMenu"
+      :close-on-content-click="false"
+      max-width="500"
+    >
+      <template #activator="{ props }">
+        <v-list-item v-bind="props">
+          <template #prepend>
+            <v-icon
+              color="warning"
+              :icon="mdiDelete"
+            />
+          </template>
+          {{ t('deleteGroup') }}
+        </v-list-item>
+      </template>
+      <v-card
+        rounded="lg"
+        variant="elevated"
+        :title="t('deletingGroup')"
+        :loading="deleteGroup.loading.value ? 'warning' : undefined"
+      >
+        <v-card-text class="pb-0">
+          <v-alert
+            class="mt-4"
+            type="warning"
+            variant="outlined"
+            :text="t('deleteGroupWarning')"
+          />
+          <v-select
+            v-if="deletableGroups.length"
+            v-model="deleteGroupId"
+            :items="deletableGroups"
+            item-title="title"
+            item-value="_id"
+            :label="t('selectGroupToDelete')"
+            class="mt-4"
+            density="comfortable"
+            hide-details
+            variant="outlined"
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            :disabled="deleteGroup.loading.value"
+            @click="deleteGroupMenu = false"
+          >
+            {{ t('cancel') }}
+          </v-btn>
+          <v-btn
             color="warning"
-            :icon="mdiDelete"
-          />
-        </template>
-        {{ t('deleteGroup') }}
-      </v-list-item>
-    </template>
-    <v-card
-      rounded="lg"
-      variant="elevated"
-      :title="t('deletingGroup')"
-      :loading="deleteGroup.loading.value ? 'warning' : undefined"
-    >
-      <v-card-text class="pb-0">
-        <v-alert
-          class="mt-4"
-          type="warning"
-          variant="outlined"
-          :text="t('deleteGroupWarning')"
-        />
-        <v-select
-          v-if="deletableGroups.length"
-          v-model="deleteGroupId"
-          :items="deletableGroups"
-          item-title="title"
-          item-value="_id"
-          :label="t('selectGroupToDelete')"
-          class="mt-4"
-          density="comfortable"
-          hide-details
-          variant="outlined"
-        />
-      </v-card-text>
-      <v-card-actions>
-        <v-spacer />
-        <v-btn
-          :disabled="deleteGroup.loading.value"
-          @click="deleteGroupMenu = false"
-        >
-          {{ t('cancel') }}
-        </v-btn>
-        <v-btn
-          color="warning"
-          variant="flat"
-          :loading="deleteGroup.loading.value"
-          :disabled="!deleteGroupId"
-          @click="deleteGroup.execute()"
-        >
-          {{ t('delete') }}
-        </v-btn>
-      </v-card-actions>
-    </v-card>
-  </v-menu>
+            variant="flat"
+            :loading="deleteGroup.loading.value"
+            :disabled="!deleteGroupId"
+            @click="deleteGroup.execute()"
+          >
+            {{ t('delete') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-menu>
 
-  <!-- Search field -->
-  <v-text-field
-    v-model="search"
-    :append-inner-icon="mdiMagnify"
-    :label="t('search')"
-    class="mt-4 mx-4"
-    color="primary"
-    density="compact"
-    variant="outlined"
-    autofocus
-    hide-details
-    clearable
-  />
+    <!-- Search field -->
+    <df-search-field
+      v-model="search"
+      class="mt-4"
+    />
 
-  <!-- Portals filters -->
-  <v-autocomplete
-    v-model="portalsSelected"
-    :items="portalsItems"
-    item-title="display"
-    item-value="portalId"
-    :label="t('portal')"
-    chips
-    class="mt-4 mx-4"
-    clearable
-    closable-chips
-    density="compact"
-    hide-details
-    multiple
-    rounded="xl"
-    variant="outlined"
-  />
+    <!-- Sort field -->
+    <sort-field
+      v-model="sort"
+      :disabled="!!search"
+    />
 
-  <!-- Page types filters -->
-  <v-autocomplete
-    v-model="typesSelected"
-    :items="typesItems"
-    item-title="display"
-    item-value="type"
-    class="mt-4 mx-4"
-    density="compact"
-    :label="t('pageType.title')"
-    rounded="xl"
-    variant="outlined"
-    hide-details
-    chips
-    clearable
-    closable-chips
-    multiple
-  />
+    <!-- Portals filters -->
+    <v-autocomplete
+      v-model="portalsSelected"
+      :items="portalsItems"
+      item-title="display"
+      item-value="portalId"
+      :label="t('portal')"
+      class="mt-4 mx-4"
+      chips
+      closable-chips
+      multiple
+    />
 
-  <!-- Page groups filters -->
-  <v-autocomplete
-    v-if="groupsItems.length > 0"
-    v-model="groupsSelected"
-    :items="groupsItems"
-    item-title="display"
-    item-value="id"
-    class="mt-4 mx-4"
-    density="compact"
-    :label="t('pageGroup')"
-    rounded="xl"
-    variant="outlined"
-    hide-details
-    chips
-    clearable
-    closable-chips
-    multiple
-  />
+    <!-- Page types filters -->
+    <v-autocomplete
+      v-model="typesSelected"
+      :items="typesItems"
+      item-title="display"
+      item-value="type"
+      :label="t('pageType.title')"
+      class="mt-4 mx-4"
+      chips
+      closable-chips
+      multiple
+    />
 
-  <!-- Show all switch (admin only) -->
-  <v-switch
-    v-if="session.user.value.adminMode"
-    v-model="showAll"
-    color="admin"
-    class="mx-4 text-admin"
-    :label="t('showAllPages')"
-    hide-details
-  />
+    <!-- Page groups filters -->
+    <v-autocomplete
+      v-if="groupsItems.length > 0"
+      v-model="groupsSelected"
+      :items="groupsItems"
+      item-title="display"
+      item-value="id"
+      :label="t('pageGroup')"
+      class="mt-4 mx-4"
+      chips
+      closable-chips
+      multiple
+    />
 
-  <!-- Owner filters (only if showAll and admin) -->
-  <v-autocomplete
-    v-if="showAll"
-    v-model="ownersSelected"
-    :items="ownersItems"
-    item-title="display"
-    item-value="ownerKey"
-    :label="t('owner')"
-    chips
-    class="mt-2 mx-4 text-admin"
-    clearable
-    closable-chips
-    density="compact"
-    hide-details
-    multiple
-    rounded="xl"
-    variant="outlined"
-  />
+    <!-- Show all switch (admin only) -->
+    <v-switch
+      v-if="session.user.value.adminMode"
+      v-model="showAll"
+      color="admin"
+      class="mx-4 text-admin"
+      :label="t('showAllPages')"
+    />
+
+    <!-- Owner filters (only if showAll and admin) -->
+    <v-autocomplete
+      v-if="showAll"
+      v-model="ownersSelected"
+      :items="ownersItems"
+      item-title="display"
+      item-value="ownerKey"
+      :label="t('owner')"
+      class="mt-2 mx-4 text-admin"
+      chips
+      closable-chips
+      multiple
+    />
+  </df-navigation-right>
 </template>
 
 <script setup lang="ts">
 import type { PagesFacets } from '#api/doc/pages/get-res/index.ts'
 import type { Group } from '#api/types/group'
 import { useRules } from 'vuetify/labs/rules'
-import { mdiMagnify, mdiPlusCircle, mdiPencil, mdiDelete, mdiFolderPlusOutline } from '@mdi/js'
+import { mdiPlusCircle, mdiPencil, mdiDelete, mdiFolderPlusOutline } from '@mdi/js'
+import dfNavigationRight from '@data-fair/lib-vuetify/navigation-right.vue'
+import dfSearchField from '@data-fair/lib-vuetify/search-field.vue'
 
 const { t } = useI18n()
 const rules = useRules() // https://vuetifyjs.com/en/features/rules/
@@ -331,6 +312,7 @@ const rules = useRules() // https://vuetifyjs.com/en/features/rules/
 const session = useSessionAuthenticated()
 
 const search = defineModel('search', { type: String, default: '' })
+const sort = defineModel('sort', { type: String, default: 'createdAt:-1' })
 const showAll = defineModel('showAll', { type: Boolean, default: false })
 const portalsSelected = defineModel('portalsSelected', { type: Array, required: true })
 const typesSelected = defineModel('typesSelected', { type: Array, required: true })
@@ -522,8 +504,6 @@ const deleteGroup = useAsyncAction(
     create: Create
     createNewPage: Create a new page
     newPageTitle: New Page Title
-    newPageStaging: New Page Staging
-    search: Search
     createNewGroup: Create a new group
     createGroupSuccess: Group created.
     createGroupError: Error while creating the group.
@@ -580,8 +560,6 @@ const deleteGroup = useAsyncAction(
     createGroupSuccess: Groupe créé.
     createGroupError: Erreur lors de la création du groupe.
     newPageTitle: Titre de la nouvelle page
-    newPageStaging: Page de pré-production
-    search: Rechercher
     showAllPages: Voir toutes les pages
     editGroup: Modifier un groupe
     editGroupTitle: Nouveau titre du groupe

--- a/ui/src/components/portals-actions.vue
+++ b/ui/src/components/portals-actions.vue
@@ -1,62 +1,64 @@
 <template>
-  <!-- Create new portal -->
-  <custom-router-link :to="'/portals/new'">
-    <v-list-item link>
-      <template #prepend>
-        <v-icon
-          color="primary"
-          :icon="mdiPlusCircle"
-        />
-      </template>
-      {{ t('createNewPortal') }}
-    </v-list-item>
-  </custom-router-link>
+  <df-navigation-right>
+    <!-- Create new portal -->
+    <custom-router-link :to="'/portals/new'">
+      <v-list-item link>
+        <template #prepend>
+          <v-icon
+            color="primary"
+            :icon="mdiPlusCircle"
+          />
+        </template>
+        {{ t('createNewPortal') }}
+      </v-list-item>
+    </custom-router-link>
 
-  <!-- Manage fonts -->
-  <custom-router-link :to="'/portals/font-assets'">
-    <v-list-item link>
-      <template #prepend>
-        <v-icon
-          color="primary"
-          :icon="mdiFormatFont"
-        />
-      </template>
-      {{ t('manageFontAssets') }}
-    </v-list-item>
-  </custom-router-link>
+    <!-- Manage fonts -->
+    <custom-router-link :to="'/portals/font-assets'">
+      <v-list-item link>
+        <template #prepend>
+          <v-icon
+            color="primary"
+            :icon="mdiFormatFont"
+          />
+        </template>
+        {{ t('manageFontAssets') }}
+      </v-list-item>
+    </custom-router-link>
 
-  <!-- Search field -->
-  <v-text-field
-    v-model="search"
-    :append-inner-icon="mdiMagnify"
-    :label="t('search')"
-    class="mt-4 mx-4"
-    color="primary"
-    density="compact"
-    variant="outlined"
-    autofocus
-    hide-details
-    clearable
-  />
+    <!-- Search field -->
+    <df-search-field
+      v-model="search"
+      class="mt-4"
+    />
 
-  <!-- Show all switch (admin only) -->
-  <v-switch
-    v-if="session.user.value.adminMode"
-    v-model="showAll"
-    color="admin"
-    class="mx-4 text-admin"
-    :label="t('showAllPortals')"
-    hide-details
-  />
+    <!-- Sort field -->
+    <sort-field
+      v-model="sort"
+      title-field="config.title"
+    />
+
+    <!-- Show all switch (admin only) -->
+    <v-switch
+      v-if="session.user.value.adminMode"
+      v-model="showAll"
+      color="admin"
+      class="mx-4 text-admin"
+      :label="t('showAllPortals')"
+    />
+  </df-navigation-right>
 </template>
 
 <script setup lang="ts">
-import { mdiFormatFont, mdiMagnify, mdiPlusCircle } from '@mdi/js'
+import { mdiFormatFont, mdiPlusCircle } from '@mdi/js'
+import dfSearchField from '@data-fair/lib-vuetify/search-field.vue'
+import dfNavigationRight from '@data-fair/lib-vuetify/navigation-right.vue'
 
 const { t } = useI18n()
 const session = useSessionAuthenticated()
 
 const search = defineModel('search', { type: String, default: '' })
+const sort = defineModel('sort', { type: String, default: 'createdAt:-1' })
 const showAll = defineModel('showAll', { type: Boolean, default: false })
 
 </script>
@@ -64,13 +66,11 @@ const showAll = defineModel('showAll', { type: Boolean, default: false })
 <i18n lang="yaml">
   en:
     createNewPortal: Create a new portal
-    search: Search
     showAllPortals: Show all portals
     manageFontAssets: Manage fonts
 
   fr:
     createNewPortal: Créer un nouveau portail
-    search: Rechercher
     showAllPortals: Voir tous les portails
     manageFontAssets: Gérer les polices de caractères
 

--- a/ui/src/components/reuses-actions.vue
+++ b/ui/src/components/reuses-actions.vue
@@ -1,80 +1,79 @@
 <template>
-  <!-- Create new reuse -->
-  <custom-router-link :to="`/reuses/new`">
-    <v-list-item link>
-      <template #prepend>
-        <v-icon
-          color="primary"
-          :icon="mdiPlusCircle"
-        />
-      </template>
-      {{ t('createNewReuse') }}
-    </v-list-item>
-  </custom-router-link>
-
-  <!-- Notifications menu -->
-  <v-menu
-    v-if="eventsSubscribeUrl"
-    v-model="showNotifMenu"
-    :close-on-content-click="false"
-    max-width="500"
-  >
-    <template #activator="{ props }">
-      <v-list-item
-        v-bind="props"
-        rounded
-      >
+  <df-navigation-right>
+    <!-- Create new reuse -->
+    <custom-router-link :to="`/reuses/new`">
+      <v-list-item link>
         <template #prepend>
           <v-icon
             color="primary"
-            :icon="mdiBell"
+            :icon="mdiPlusCircle"
           />
         </template>
-        {{ t('notifications') }}
+        {{ t('createNewReuse') }}
       </v-list-item>
-    </template>
-    <v-card
-      :title="t('notifications')"
-      rounded="lg"
+    </custom-router-link>
+
+    <!-- Notifications menu -->
+    <v-menu
+      v-if="eventsSubscribeUrl"
+      v-model="showNotifMenu"
+      :close-on-content-click="false"
+      max-width="500"
     >
-      <v-card-text class="pa-0">
-        <d-frame-wrapper :src="eventsSubscribeUrl" />
-      </v-card-text>
-    </v-card>
-  </v-menu>
+      <template #activator="{ props }">
+        <v-list-item
+          v-bind="props"
+          rounded
+        >
+          <template #prepend>
+            <v-icon
+              color="primary"
+              :icon="mdiBell"
+            />
+          </template>
+          {{ t('notifications') }}
+        </v-list-item>
+      </template>
+      <v-card
+        :title="t('notifications')"
+        rounded="lg"
+      >
+        <v-card-text class="pa-0">
+          <d-frame-wrapper :src="eventsSubscribeUrl" />
+        </v-card-text>
+      </v-card>
+    </v-menu>
 
-  <!-- Search field -->
-  <v-text-field
-    v-model="search"
-    :append-inner-icon="mdiMagnify"
-    :label="t('search')"
-    class="mt-4 mx-4"
-    color="primary"
-    density="compact"
-    variant="outlined"
-    autofocus
-    hide-details
-    clearable
-  />
+    <!-- Search field -->
+    <df-search-field
+      v-model="search"
+      class="mt-4"
+    />
 
-  <!-- Show all switch (admin only) -->
-  <v-switch
-    v-if="session.user.value.adminMode"
-    v-model="showAll"
-    color="admin"
-    class="mx-4 text-admin"
-    :label="t('showAllReuses')"
-    hide-details
-  />
+    <!-- Sort field -->
+    <sort-field v-model="sort" />
+
+    <!-- Show all switch (admin only) -->
+    <v-switch
+      v-if="session.user.value.adminMode"
+      v-model="showAll"
+      color="admin"
+      class="mx-4 text-admin"
+      :label="t('showAllReuses')"
+    />
+  </df-navigation-right>
 </template>
 
 <script setup lang="ts">
-import { mdiMagnify, mdiPlusCircle, mdiBell } from '@mdi/js'
+import { mdiPlusCircle, mdiBell } from '@mdi/js'
+import dfSearchField from '@data-fair/lib-vuetify/search-field.vue'
+import dfNavigationRight from '@data-fair/lib-vuetify/navigation-right.vue'
 
 const { t } = useI18n()
 const session = useSessionAuthenticated()
 
 const search = defineModel('search', { type: String, default: '' })
+const sort = defineModel('sort', { type: String, default: 'createdAt:-1' })
 const showAll = defineModel('showAll', { type: Boolean, default: false })
 const showNotifMenu = ref(false)
 
@@ -90,14 +89,12 @@ const eventsSubscribeUrl = computed(() => {
 <i18n lang="yaml">
   en:
     createNewReuse: Create a new reuse
-    search: Search
     showAllReuses: Show all reuses
     notifications: Notifications
     reuseSubmittedForValidation: A reuse has been submitted for validation
 
   fr:
     createNewReuse: Créer une nouvelle réutilisation
-    search: Rechercher
     showAllReuses: Voir toutes les réutilisations
     notifications: Notifications
     reuseSubmittedForValidation: Une réutilisation a été soumise pour validation

--- a/ui/src/components/sort-field.vue
+++ b/ui/src/components/sort-field.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-tooltip
+    :disabled="!disabled"
+    :text="t('sortDisabledRelevance')"
+    location="bottom"
+  >
+    <template #activator="{ props: tooltipProps }">
+      <div
+        v-bind="tooltipProps"
+        :class="{ 'cursor-not-allowed': disabled }"
+      >
+        <v-select
+          v-model="sort"
+          :label="t('sort')"
+          :items="sortItems"
+          :clearable="false"
+          :disabled="disabled"
+          class="mt-4 mx-4"
+          rounded="md"
+        />
+      </div>
+    </template>
+  </v-tooltip>
+</template>
+
+<script setup lang="ts">
+const { t } = useI18n()
+
+const sort = defineModel({ type: String, default: 'createdAt:-1' })
+
+const { titleField = 'title', disabled } = defineProps<{
+  titleField?: string
+  disabled?: boolean
+}>()
+
+const sortItems = computed(() => [
+  { title: t('sortCreatedAtDesc'), value: 'createdAt:-1' },
+  { title: t('sortCreatedAtAsc'), value: 'createdAt:1' },
+  { title: t('sortUpdatedAtDesc'), value: 'updatedAt:-1' },
+  { title: t('sortUpdatedAtAsc'), value: 'updatedAt:1' },
+  { title: t('sortTitleAsc'), value: `${titleField}:1` },
+  { title: t('sortTitleDesc'), value: `${titleField}:-1` },
+])
+</script>
+
+<i18n lang="yaml">
+  en:
+    sort: Sort by
+    sortDisabledRelevance: "Sorting is disabled during a search: results are sorted by relevance"
+    sortCreatedAtDesc: Creation (newest)
+    sortCreatedAtAsc: Creation (oldest)
+    sortUpdatedAtDesc: Update (newest)
+    sortUpdatedAtAsc: Update (oldest)
+    sortTitleAsc: Title (A → Z)
+    sortTitleDesc: Title (Z → A)
+
+  fr:
+    sort: Trier par
+    sortDisabledRelevance: "Le tri est désactivé pendant une recherche : les résultats sont triés par pertinence"
+    sortCreatedAtDesc: Création (plus récent)
+    sortCreatedAtAsc: Création (plus ancien)
+    sortUpdatedAtDesc: Mise à jour (plus récente)
+    sortUpdatedAtAsc: Mise à jour (plus ancienne)
+    sortTitleAsc: Titre (A → Z)
+    sortTitleDesc: Titre (Z → A)
+</i18n>

--- a/ui/src/pages/pages/index.vue
+++ b/ui/src/pages/pages/index.vue
@@ -23,7 +23,7 @@
 
     <!-- No pages created -->
     <span
-      v-else-if="!pagesFetch.data.value?.results.length"
+      v-else-if="!pagesFetch.data.value?.results.length && !isFiltered"
       class="d-flex justify-center text-title-large mt-4"
     >
       {{ t('noPagesCreated') }}
@@ -57,28 +57,37 @@
     </v-row>
 
     <!-- Actions -->
-    <navigation-right>
-      <pages-actions
-        v-model:search="search"
-        v-model:show-all="showAll"
-        v-model:portals-selected="portals"
-        v-model:types-selected="types"
-        v-model:groups-selected="groups"
-        v-model:owners-selected="owners"
-        :facets="facets"
-      />
-    </navigation-right>
+    <pages-actions
+      v-model:search="search"
+      v-model:sort="sort"
+      v-model:show-all="showAll"
+      v-model:portals-selected="portals"
+      v-model:types-selected="types"
+      v-model:groups-selected="groups"
+      v-model:owners-selected="owners"
+      :facets="facets"
+    />
   </v-container>
 </template>
 
 <script setup lang="ts">
 import type { Page } from '#api/types/page'
 import type { PagesGetRes, PagesFacets } from '#api/doc/pages/get-res'
-import NavigationRight from '@data-fair/lib-vuetify/navigation-right.vue'
 
 const { t } = useI18n()
 const showAll = useBooleanSearchParam('showAll')
-const search = useStringSearchParam('q')
+
+// Search with debounce
+const q = useStringSearchParam('q')
+const search = ref(q.value || '')
+let searchTimeout: ReturnType<typeof setTimeout> | undefined
+watch(search, (val) => {
+  clearTimeout(searchTimeout)
+  searchTimeout = setTimeout(() => { q.value = val || '' }, 300)
+})
+watch(q, (val) => { if (val !== search.value) search.value = val || '' })
+
+const sort = useStringSearchParam('sort', 'createdAt:-1')
 const portals = useStringsArraySearchParam('portal')
 const types = useStringsArraySearchParam('type')
 const groups = useStringsArraySearchParam('group')
@@ -87,9 +96,10 @@ const owners = useStringsArraySearchParam('owner')
 const pagesParams = computed(() => {
   const params: Record<string, any> = {
     size: 1000,
-    sort: 'updatedAt:-1',
     select: '_id,title,type,owner,config.description,config.genericMetadata'
   }
+  if (q.value) params.q = q.value
+  else params.sort = sort.value
   if (types.value.length) params.type = types.value.join(',')
   if (portals.value.length) params.portal = portals.value.join(',')
   if (owners.value.length) params.owners = owners.value.join(',')
@@ -101,12 +111,11 @@ const facets = computed<PagesFacets>(() => pagesFetch.data.value?.facets ?? { ty
 
 const displayPages = computed(() => {
   const pages = (pagesFetch.data.value?.results ?? [])
-  return pages.filter(page => {
-    if (search.value && !page.title.toLowerCase().includes(search.value.toLowerCase())) return false
-    if (!groups.value.length) return true
-    return groups.value.includes(getPageGroupId(page))
-  })
+  if (!groups.value.length) return pages
+  return pages.filter(page => groups.value.includes(getPageGroupId(page)))
 })
+
+const isFiltered = computed(() => !!q.value || types.value.length > 0 || portals.value.length > 0 || owners.value.length > 0 || groups.value.length > 0)
 
 const standardTypes = new Set([
   'home',

--- a/ui/src/pages/portals/index.vue
+++ b/ui/src/pages/portals/index.vue
@@ -55,22 +55,22 @@
     </template>
 
     <!-- Actions -->
-    <navigation-right v-if="portalsFetch.data.value">
-      <portals-actions
-        v-model:search="search"
-        v-model:show-all="showAll"
-      />
-    </navigation-right>
+    <portals-actions
+      v-if="portalsFetch.data.value"
+      v-model:search="search"
+      v-model:sort="sort"
+      v-model:show-all="showAll"
+    />
   </v-container>
 </template>
 
 <script setup lang="ts">
 import type { Portal } from '#api/types/portal/index'
-import NavigationRight from '@data-fair/lib-vuetify/navigation-right.vue'
 
 const session = useSessionAuthenticated()
 const showAll = useBooleanSearchParam('showAll')
 const search = useStringSearchParam('q')
+const sort = useStringSearchParam('sort', 'createdAt:-1')
 const { t } = useI18n()
 
 // Restrict to portals actually owned by the session's account: drops portals
@@ -85,7 +85,7 @@ const ownerFilter = computed(() => {
 const portalsParams = computed(() => {
   const params: Record<string, any> = {
     size: 10000,
-    sort: 'updatedAt:-1',
+    sort: sort.value,
     select: '_id,config.title,config.description,config.authentication,ingress.url,owner',
     owner: ownerFilter.value
   }

--- a/ui/src/pages/reuses/index.vue
+++ b/ui/src/pages/reuses/index.vue
@@ -53,27 +53,26 @@
     </v-row>
 
     <!-- Actions -->
-    <navigation-right>
-      <reuses-actions
-        v-model:search="search"
-        v-model:show-all="showAll"
-      />
-    </navigation-right>
+    <reuses-actions
+      v-model:search="search"
+      v-model:sort="sort"
+      v-model:show-all="showAll"
+    />
   </v-container>
 </template>
 
 <script setup lang="ts">
 import type { Reuse } from '#api/types/reuse/index'
-import NavigationRight from '@data-fair/lib-vuetify/navigation-right.vue'
 
 const showAll = useBooleanSearchParam('showAll')
 const search = useStringSearchParam('q')
+const sort = useStringSearchParam('sort', 'createdAt:-1')
 const { t } = useI18n()
 
 const reusesParams = computed(() => {
   const params: Record<string, any> = {
-    size: 1000,
-    sort: 'updatedAt:-1',
+    size: 10000,
+    sort: sort.value,
     select: '_id,title,owner,requestedPortals'
   }
   if (showAll.value) params.showAll = 'true'


### PR DESCRIPTION
Add a sort selector to the navigation drawers of the pages, portals and reuses lists, alongside the search field.

**What changed:**
- New reusable `sort-field` component (in the spirit of `df-search-field`) wired into the three list drawers
- Pages: server-side text search (`$text`) with relevance sort (`textScore`) while searching — the sort selector is disabled with an explanatory tooltip; outside of a search the chosen sort applies
- Portals & reuses: client-side search (`size: 10000`), sort always active
- Search inputs unified on the lib's `df-search-field`
- `df-navigation-right` moved directly into each actions component (the `index.vue` files now only render `<xxx-actions>`)
- `sort-field` takes a `titleField` prop (default `title`) so portals can sort on `config.title` without duplicating labels

**Why:** add the same sort block as data-fair to the portals-manager list views.

**Regression risks:**
- `api/src/pages/router.ts`: while a search is active, sorting switches to `{ _score: { $meta: 'textScore' } }`, which relies on the existing `$text` index on the `pages` collection. Pages only — portals/reuses are unaffected.
- Portals & reuses now fetch `size: 10000` for client-side filtering (deliberate; no relevance sort during client search).
- `portals/index.vue`: the load guard `v-if` moved from the old `<navigation-right>` wrapper onto `<portals-actions>` — behavior verified identical.