### PR TITLE
feat: add a root page to groups for breadcrumb linking

### DIFF
--- a/api/doc/groups/patch-req-body/schema.js
+++ b/api/doc/groups/patch-req-body/schema.js
@@ -3,7 +3,7 @@ import groupSchema from '#types/group/schema.js'
 
 export default {
   ...jsonSchema(groupSchema)
-    .pickProperties(['title', 'description'])
+    .pickProperties(['title', 'description', 'rootPage'])
     .removeFromRequired(['description'])
     .schema,
   $id: 'https://github.com/data-fair/portals/groups/patch-req-body',

--- a/api/doc/groups/post-req-body/schema.js
+++ b/api/doc/groups/post-req-body/schema.js
@@ -3,7 +3,7 @@ import groupSchema from '#types/group/schema.js'
 
 export default {
   ...jsonSchema(groupSchema)
-    .pickProperties(['title', 'description'])
+    .pickProperties(['title', 'description', 'rootPage'])
     .removeFromRequired(['description'])
     .schema,
   $id: 'https://github.com/data-fair/portals/groups/post-req-body',

--- a/api/src/groups/service.ts
+++ b/api/src/groups/service.ts
@@ -41,6 +41,19 @@ export const patchGroup = async (group: Group, patch: Partial<Group>, session: S
       )
     ])
   }
+  // Update group root page in pages
+  if ('rootPage' in fullPatch && fullPatch.rootPage !== group.rootPage) {
+    await Promise.all([
+      mongo.pages.updateMany(
+        { 'config.genericMetadata.group._id': group._id },
+        { $set: { 'config.genericMetadata.group.rootPage': fullPatch.rootPage ?? '' } }
+      ),
+      mongo.pages.updateMany(
+        { 'draftConfig.genericMetadata.group._id': group._id },
+        { $set: { 'draftConfig.genericMetadata.group.rootPage': fullPatch.rootPage ?? '' } }
+      )
+    ])
+  }
   return updatedGroup
 }
 

--- a/api/types/group/schema.js
+++ b/api/types/group/schema.js
@@ -24,6 +24,11 @@ export default {
       title: 'Description',
       description: 'Une zone de texte libre pour décrire le groupe. Elle sera affichée sur la vignette du groupe.'
     },
+    rootPage: {
+      type: 'string',
+      title: 'Page racine',
+      description: "Slug d'une page utilisée comme racine du groupe pour le fil d'Ariane des pages du groupe."
+    },
     owner: { $ref: 'https://github.com/data-fair/lib/account' },
     createdAt: { $ref: 'https://github.com/data-fair/portals/partial#/$defs/createdAt' },
     updatedAt: { $ref: 'https://github.com/data-fair/portals/partial#/$defs/updatedAt' }

--- a/api/types/page-config/schema.js
+++ b/api/types/page-config/schema.js
@@ -111,7 +111,7 @@ export default {
           required: ['_id', 'title', 'slug'],
           layout: {
             getItems: {
-              url: '/portals-manager/api/groups?select=_id,title,slug',
+              url: '/portals-manager/api/groups?select=_id,title,slug,rootPage',
               itemsResults: 'data.results',
               itemTitle: 'item.title',
               itemKey: 'item._id'
@@ -120,7 +120,8 @@ export default {
           properties: {
             _id: { type: 'string' },
             title: { type: 'string' },
-            slug: { type: 'string' }
+            slug: { type: 'string' },
+            rootPage: { type: 'string' }
           }
         }
       }

--- a/portal/app/pages/pages-[groupSlug]/[pageSlug].vue
+++ b/portal/app/pages/pages-[groupSlug]/[pageSlug].vue
@@ -25,12 +25,12 @@ const pageConfigFetch = await useFetch<PageConfig>(`/portal/api/pages/generic/${
 provide('page-config', pageConfigFetch.data)
 
 watch(() => pageConfigFetch.data.value, (pageConfig) => {
-  // Breadcrumbs with group if available
-  const items = [{ title: pageConfig?.title || portalConfig.value.title }]
-  if (pageConfig?.genericMetadata?.group?.title) {
-    items.unshift({ title: pageConfig.genericMetadata.group.title })
-  }
-  setBreadcrumbs(items)
+  // Breadcrumbs with group if available, linking to its root page when defined
+  const group = pageConfig?.genericMetadata?.group
+  setBreadcrumbs([
+    ...(group?.title ? [{ title: group.title, to: group.rootPage ? `/pages/${group.rootPage}` : undefined }] : []),
+    { title: pageConfig?.title || portalConfig.value.title }
+  ])
   setShowBreadcrumbs(pageConfig?.showBreadcrumbs)
 }, { immediate: true })
 

--- a/ui/src/components/group-form.vue
+++ b/ui/src/components/group-form.vue
@@ -1,0 +1,210 @@
+<template>
+  <v-menu
+    v-model="menu"
+    location="start"
+    :close-on-content-click="false"
+  >
+    <template #activator="{ props }">
+      <v-list-item v-bind="props">
+        <template #prepend>
+          <v-icon
+            color="primary"
+            :icon="isEdit ? mdiPencil : mdiFolderPlusOutline"
+          />
+        </template>
+        {{ isEdit ? t('editGroup') : t('createNewGroup') }}
+      </v-list-item>
+    </template>
+    <v-card
+      data-iframe-height
+      min-width="300"
+      rounded="lg"
+      :loading="save.loading.value ? 'primary' : undefined"
+    >
+      <v-card-text>
+        <v-select
+          v-if="isEdit"
+          v-model="selectedId"
+          :items="groups"
+          item-title="title"
+          item-value="_id"
+          :label="t('selectGroup')"
+          density="comfortable"
+          variant="outlined"
+          hide-details
+        />
+        <v-text-field
+          v-model="title"
+          :label="t('titleLabel')"
+          density="comfortable"
+          variant="outlined"
+          :autofocus="!isEdit"
+          hide-details="auto"
+          :disabled="isEdit && !selectedId"
+          :class="{ 'mt-4': isEdit }"
+        />
+        <v-textarea
+          v-model="description"
+          :label="t('descriptionLabel')"
+          :rules="[rules.maxLength(100)]"
+          class="mt-4"
+          density="comfortable"
+          hide-details="auto"
+          variant="outlined"
+          no-resize
+          rows="3"
+          auto-grow
+          :disabled="isEdit && !selectedId"
+        />
+        <v-autocomplete
+          v-model="rootPage"
+          :items="rootPageItems"
+          item-title="display"
+          item-value="slug"
+          :label="t('rootPage')"
+          :hint="t('rootPageHint')"
+          persistent-hint
+          clearable
+          class="mt-4"
+          density="comfortable"
+          variant="outlined"
+          :disabled="isEdit && !selectedId"
+        />
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn
+          :disabled="save.loading.value"
+          @click="menu = false"
+        >
+          {{ t('cancel') }}
+        </v-btn>
+        <v-btn
+          color="primary"
+          variant="flat"
+          :disabled="!canSave"
+          :loading="save.loading.value ? 'primary' : false"
+          @click="save.execute()"
+        >
+          {{ isEdit ? t('save') : t('create') }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-menu>
+</template>
+
+<script setup lang="ts">
+import type { Group } from '#api/types/group'
+import { useRules } from 'vuetify/labs/rules'
+import { mdiPencil, mdiFolderPlusOutline } from '@mdi/js'
+
+const { t } = useI18n()
+const rules = useRules() // https://vuetifyjs.com/en/features/rules/
+
+const { mode, groups = [] } = defineProps<{
+  mode: 'create' | 'edit',
+  groups?: Group[]
+}>()
+const emit = defineEmits<{ (e: 'saved'): void }>()
+
+const isEdit = mode === 'edit'
+
+const menu = ref(false)
+const selectedId = ref<string | null>(null)
+const title = ref('')
+const description = ref('')
+const rootPage = ref<string | null>(null)
+
+// Standalone generic pages (without group) usable as a group's root page, fetched lazily when the menu opens
+const rootPagesFetch = useFetch<{ results: Array<{ config: { title: string, genericMetadata?: { slug?: string } } }> }>(
+  $apiPath + '/pages',
+  {
+    query: { type: 'generic', groupId: 'default', select: 'config.title,config.genericMetadata.slug', size: 1000 },
+    waitFor: () => menu.value
+  }
+)
+
+const rootPageItems = computed(() =>
+  (rootPagesFetch.data.value?.results ?? [])
+    .map(page => ({ display: page.config.title, slug: page.config.genericMetadata?.slug }))
+    .filter((item): item is { display: string, slug: string } => !!item.slug)
+    .sort((a, b) => a.display.localeCompare(b.display))
+)
+
+const canSave = computed(() =>
+  !!title.value && description.value.length <= 100 && (!isEdit || !!selectedId.value)
+)
+
+const loadSelected = () => {
+  const group = groups.find(item => item._id === selectedId.value)
+  title.value = group?.title || ''
+  description.value = group?.description || ''
+  rootPage.value = group?.rootPage || null
+}
+
+watch(menu, (open) => {
+  if (!open) return
+  if (isEdit) {
+    if (!selectedId.value && groups.length) selectedId.value = groups[0]._id
+    loadSelected()
+  } else {
+    title.value = ''
+    description.value = ''
+    rootPage.value = null
+  }
+})
+
+watch(selectedId, () => { if (isEdit) loadSelected() })
+
+const save = useAsyncAction(
+  async () => {
+    const body = { title: title.value, description: description.value, rootPage: rootPage.value || '' }
+    if (isEdit) {
+      if (!selectedId.value) return
+      await $fetch(`/groups/${selectedId.value}`, { method: 'PATCH', body })
+    } else {
+      await $fetch<Group>('/groups', { method: 'POST', body })
+    }
+    emit('saved')
+    menu.value = false
+  },
+  {
+    success: isEdit ? t('editGroupSuccess') : t('createGroupSuccess'),
+    error: isEdit ? t('editGroupError') : t('createGroupError')
+  }
+)
+</script>
+
+<i18n lang="yaml">
+  en:
+    cancel: Cancel
+    create: Create
+    save: Save
+    createNewGroup: Create a new group
+    editGroup: Edit a group
+    selectGroup: Select a group
+    titleLabel: Group title
+    descriptionLabel: Description
+    rootPage: Root page
+    rootPageHint: Custom page used as the group's root in the breadcrumb.
+    createGroupSuccess: Group created.
+    createGroupError: Error while creating the group.
+    editGroupSuccess: Group updated.
+    editGroupError: Error while updating the group.
+
+  fr:
+    cancel: Annuler
+    create: Créer
+    save: Enregistrer
+    createNewGroup: Créer un nouveau groupe
+    editGroup: Modifier un groupe
+    selectGroup: Choisir un groupe
+    titleLabel: Titre du groupe
+    descriptionLabel: Description
+    rootPage: Page racine
+    rootPageHint: Page de contenu libre utilisée comme racine du groupe dans le fil d'Ariane.
+    createGroupSuccess: Groupe créé.
+    createGroupError: Erreur lors de la création du groupe.
+    editGroupSuccess: Groupe modifié.
+    editGroupError: Erreur lors de la modification du groupe.
+</i18n>

--- a/ui/src/components/pages-actions.vue
+++ b/ui/src/components/pages-actions.vue
@@ -14,148 +14,17 @@
     </custom-router-link>
 
     <!-- Create new group -->
-    <v-menu
-      v-model="newGroupMenu"
-      location="start"
-      :close-on-content-click="false"
-    >
-      <template #activator="{ props }">
-        <v-list-item v-bind="props">
-          <template #prepend>
-            <v-icon
-              color="primary"
-              :icon="mdiFolderPlusOutline"
-            />
-          </template>
-          {{ t('createNewGroup') }}
-        </v-list-item>
-      </template>
-      <v-card
-        data-iframe-height
-        min-width="300"
-        rounded="lg"
-        :loading="createGroup.loading.value ? 'primary' : undefined"
-      >
-        <v-card-text>
-          <v-text-field
-            v-model="newGroupTitle"
-            :label="t('newGroupTitle')"
-            density="comfortable"
-            variant="outlined"
-            autofocus
-            auto-grow
-            hide-details
-          />
-          <v-textarea
-            v-model="newGroupDescription"
-            :label="t('newGroupDescription')"
-            :rules="[rules.maxLength(100)]"
-            :counter="100"
-            class="mt-4"
-            density="comfortable"
-            hide-details="auto"
-            variant="outlined"
-            no-resize
-          />
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn
-            :disabled="createGroup.loading.value"
-            @click="newGroupMenu = false"
-          >
-            {{ t('cancel') }}
-          </v-btn>
-          <v-btn
-            color="primary"
-            variant="flat"
-            :disabled="!newGroupTitle || newGroupDescription.length > 100"
-            :loading="createGroup.loading.value ? 'primary' : false"
-            @click="createGroup.execute()"
-          >
-            {{ t('create') }}
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-menu>
+    <group-form
+      mode="create"
+      @saved="groupsFetch.refresh()"
+    />
 
-    <!-- Group management menu -->
-    <v-menu
-      v-model="editGroupMenu"
-      location="start"
-      :close-on-content-click="false"
-    >
-      <template #activator="{ props }">
-        <v-list-item v-bind="props">
-          <template #prepend>
-            <v-icon
-              color="primary"
-              :icon="mdiPencil"
-            />
-          </template>
-          {{ t('editGroup') }}
-        </v-list-item>
-      </template>
-      <v-card
-        data-iframe-height
-        min-width="300"
-        rounded="lg"
-        :loading="editGroup.loading.value ? 'primary' : undefined"
-      >
-        <v-card-text>
-          <v-select
-            v-model="editGroupId"
-            :items="editableGroups"
-            item-title="title"
-            item-value="_id"
-            :label="t('selectGroup')"
-            density="comfortable"
-            variant="outlined"
-            hide-details
-          />
-          <v-text-field
-            v-model="editGroupTitle"
-            :label="t('editGroupTitle')"
-            density="comfortable"
-            variant="outlined"
-            :disabled="!editGroupId"
-            class="mt-4"
-            auto-grow
-            hide-details
-          />
-          <v-textarea
-            v-model="editGroupDescription"
-            :label="t('editGroupDescription')"
-            :rules="[rules.maxLength(100)]"
-            :counter="100"
-            class="mt-4"
-            density="comfortable"
-            hide-details="auto"
-            variant="outlined"
-            no-resize
-            :disabled="!editGroupId"
-          />
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn
-            :disabled="editGroup.loading.value"
-            @click="editGroupMenu = false"
-          >
-            {{ t('cancel') }}
-          </v-btn>
-          <v-btn
-            color="primary"
-            variant="flat"
-            :disabled="!editGroupId || !editGroupTitle || editGroupDescription.length > 100"
-            :loading="editGroup.loading.value ? 'primary' : false"
-            @click="editGroup.execute()"
-          >
-            {{ t('save') }}
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-menu>
+    <!-- Edit a group -->
+    <group-form
+      mode="edit"
+      :groups="editableGroups"
+      @saved="groupsFetch.refresh()"
+    />
 
     <!-- Delete group menu -->
     <v-menu
@@ -301,13 +170,11 @@
 <script setup lang="ts">
 import type { PagesFacets } from '#api/doc/pages/get-res/index.ts'
 import type { Group } from '#api/types/group'
-import { useRules } from 'vuetify/labs/rules'
-import { mdiPlusCircle, mdiPencil, mdiDelete, mdiFolderPlusOutline } from '@mdi/js'
+import { mdiPlusCircle, mdiDelete } from '@mdi/js'
 import dfNavigationRight from '@data-fair/lib-vuetify/navigation-right.vue'
 import dfSearchField from '@data-fair/lib-vuetify/search-field.vue'
 
 const { t } = useI18n()
-const rules = useRules() // https://vuetifyjs.com/en/features/rules/
 
 const session = useSessionAuthenticated()
 
@@ -319,20 +186,9 @@ const typesSelected = defineModel('typesSelected', { type: Array, required: true
 const groupsSelected = defineModel('groupsSelected', { type: Array, required: true })
 const ownersSelected = defineModel('ownersSelected', { type: Array, required: true })
 
-const { facets, currentGroupId } = defineProps<{
-  facets: PagesFacets,
-  currentGroupId?: string
+const { facets } = defineProps<{
+  facets: PagesFacets
 }>()
-const emit = defineEmits<{ (e: 'refresh-group'): void }>()
-
-const newGroupMenu = ref(false)
-const newGroupTitle = ref('')
-const newGroupDescription = ref('')
-
-const editGroupMenu = ref(false)
-const editGroupId = ref<string | null>(null)
-const editGroupTitle = ref('')
-const editGroupDescription = ref('')
 
 const deleteGroupMenu = ref(false)
 const deleteGroupId = ref<string | null>(null)
@@ -421,67 +277,11 @@ const deletableGroups = computed(() => {
   return groups.filter(group => (groupsCounts[group._id] ?? 0) === 0)
 })
 
-watch(editGroupMenu, () => {
-  if (!editGroupMenu.value) return
-  if (!editGroupId.value && editableGroups.value.length) {
-    editGroupId.value = editableGroups.value[0]._id
-  }
-  const selected = editableGroups.value.find(group => group._id === editGroupId.value)
-  editGroupTitle.value = selected?.title || ''
-  editGroupDescription.value = selected?.description || ''
-})
-
-watch(editGroupId, () => {
-  const selected = editableGroups.value.find(group => group._id === editGroupId.value)
-  editGroupTitle.value = selected?.title || ''
-  editGroupDescription.value = selected?.description || ''
-})
-
 watch(deleteGroupMenu, () => {
   if (!deleteGroupMenu.value) return
   if (deletableGroups.value.length) deleteGroupId.value = deletableGroups.value[0]._id
   else deleteGroupId.value = null
 })
-
-const createGroup = useAsyncAction(
-  async () => {
-    await $fetch<Group>('/groups', {
-      method: 'POST',
-      body: {
-        title: newGroupTitle.value,
-        description: newGroupDescription.value
-      }
-    })
-    await groupsFetch.refresh()
-    newGroupTitle.value = ''
-    newGroupDescription.value = ''
-    newGroupMenu.value = false
-  },
-  {
-    success: t('createGroupSuccess'),
-    error: t('createGroupError')
-  }
-)
-
-const editGroup = useAsyncAction(
-  async () => {
-    if (!editGroupId.value) return
-    await $fetch(`/groups/${editGroupId.value}`, {
-      method: 'PATCH',
-      body: {
-        title: editGroupTitle.value,
-        description: editGroupDescription.value
-      }
-    })
-    await groupsFetch.refresh()
-    if (editGroupId.value === currentGroupId) emit('refresh-group')
-    editGroupMenu.value = false
-  },
-  {
-    success: t('editGroupSuccess'),
-    error: t('editGroupError')
-  }
-)
 
 const deleteGroup = useAsyncAction(
   async () => {
@@ -501,25 +301,13 @@ const deleteGroup = useAsyncAction(
 <i18n lang="yaml">
   en:
     cancel: Cancel
-    create: Create
     createNewPage: Create a new page
     newPageTitle: New Page Title
-    createNewGroup: Create a new group
-    createGroupSuccess: Group created.
-    createGroupError: Error while creating the group.
     showAllPages: Show all pages
-    editGroup: Edit a Group
-    editGroupTitle: New Group Title
-    editGroupDescription: New Group Description
-    editGroupSuccess: Group updated.
-    editGroupError: Error while updating the group.
-    save: Save
     deleteGroup: Delete a group
     deletingGroup: Deleting a group
     deleteGroupSuccess: Group deleted.
     deleteGroupError: Error while deleting the group.
-    newGroupTitle: New Group Title
-    newGroupDescription: Description
     confirmDeleteGroup: Do you really want to delete the group "{title}"? Deletion is permanent and data cannot be recovered.
     groupNotEmptyError: Cannot delete the group while it contains pages
     delete: Delete
@@ -544,7 +332,6 @@ const deleteGroup = useAsyncAction(
       event: Event
       news: News
       generic: Custom content
-    selectGroup: Select a group
     selectGroupToDelete: Group to delete
     groupTitle:
       standard: Standard pages
@@ -554,21 +341,9 @@ const deleteGroup = useAsyncAction(
 
   fr:
     cancel: Annuler
-    create: Créer
     createNewPage: Créer une nouvelle page
-    createNewGroup: Créer un nouveau groupe
-    createGroupSuccess: Groupe créé.
-    createGroupError: Erreur lors de la création du groupe.
     newPageTitle: Titre de la nouvelle page
     showAllPages: Voir toutes les pages
-    editGroup: Modifier un groupe
-    editGroupTitle: Nouveau titre du groupe
-    editGroupDescription: Nouvelle description du groupe
-    editGroupSuccess: Groupe modifié.
-    editGroupError: Erreur lors de la modification du groupe.
-    newGroupTitle: Titre du nouveau groupe
-    newGroupDescription: Description
-    save: Enregistrer
     deleteGroup: Supprimer un groupe
     deletingGroup: "Suppression d'un groupe"
     deleteGroupSuccess: Groupe supprimé.
@@ -578,7 +353,6 @@ const deleteGroup = useAsyncAction(
     owner: Propriétaire
     portal: Portail
     pageGroup: Groupe
-    selectGroup: Choisir un groupe
     selectGroupToDelete: Groupe à supprimer
     groupTitle:
       standard: Pages standard


### PR DESCRIPTION
Add an optional `rootPage` to groups: the slug of a standalone generic page used as the group's root.

**Why:** make the group name clickable in the breadcrumb of group pages, pointing to a free-content page acting as the group's root.

**What changes:**
- new `rootPage` field on the group schema, accepted on group creation and update
- the root page can be set both when creating and when editing a group
- group create/edit UI extracted into a dedicated autonomous `group-form` component (mode: create | edit), instantiated twice in `pages-actions`
- on group PATCH, propagate `rootPage` to the `config` and `draftConfig` of the group's pages
- portal breadcrumb: the group name becomes a link to `/pages/<rootPage>` when set

**Regression risks:**
- group-page breadcrumb is rebuilt: order and rendering are preserved; with no `rootPage`, the group name stays a plain label (unchanged behavior)
- a group PATCH triggers an `updateMany` across all of the group's pages whenever `rootPage` changes
- `pages-actions` drops the unused `currentGroupId` prop and `refresh-group` emit (dead code; the only consumer never used them)
- the root pages list is now fetched lazily per group-form instance when the menu opens (no fetch on page load)