### PR TITLE
feat(portal): add title anchors and content page table of contents

### DIFF
--- a/api/src/pages/service.ts
+++ b/api/src/pages/service.ts
@@ -120,6 +120,7 @@ export const generateUniqueSlug = async (baseTitle: string, pageType: 'event' | 
 export const createPage = async (page: Page, sourcePageId?: string) => {
   debug('createPage', page)
   validateMetadata(page)
+  page.config._toc = await resolvePageAnchors(page.config)
   await mongo.pages.insertOne(page)
 
   const details: string[] = []
@@ -144,6 +145,7 @@ export const patchPage = async (page: Page, patch: Partial<Page>, session: Sessi
   validateMetadata(page, patch)
   if (patch.draftConfig) {
     await renderMarkdownElements(patch.draftConfig)
+    patch.draftConfig._toc = await resolvePageAnchors(patch.draftConfig)
   }
 
   // Check if trying to unpublish a home page
@@ -397,6 +399,32 @@ const validateMetadata = (page: Page, patch?: Partial<Page>) => {
     const validSlug = slug.default(metadata.slug, { lower: true, strict: true })
     if (metadata.slug !== validSlug) throw httpError(400, `Invalid slug "${metadata.slug}". An accepted format is: "${validSlug}"`)
   }
+}
+
+// Resolve each anchored title's slug from its content (deduplicating in document order)
+// and build the table of contents. The resolved slug is stored on the element (anchor._slug)
+// so the rendered title and the table of contents share the same identifier.
+const resolvePageAnchors = async (pageConfig: PageConfig) => {
+  const toc: NonNullable<PageConfig['_toc']> = []
+  const seen = new Set<string>()
+  await traversePageElements(pageConfig.elements, (element) => {
+    if (element.type !== 'title' || !element.anchor) return
+    if (!element.anchor.enabled) {
+      delete element.anchor._slug
+      return
+    }
+    const base = slug.default(element.content || 'section', { lower: true, strict: true }) || 'section'
+    let candidate = base
+    let counter = 2
+    while (seen.has(candidate)) candidate = `${base}-${counter++}`
+    seen.add(candidate)
+    element.anchor._slug = candidate
+    if (element.anchor.inToc) {
+      const label = element.anchor.label?.trim()
+      toc.push({ id: candidate, title: label || element.content || candidate })
+    }
+  })
+  return toc
 }
 
 const switchStandardPages = async (page: Page, addedPortals: string[]): Promise<Record<string, string>> => {

--- a/api/types/page-config/schema.js
+++ b/api/types/page-config/schema.js
@@ -202,6 +202,20 @@ export default {
       items: {
         $ref: 'https://github.com/data-fair/portals/page-elements#/$defs/element'
       }
+    },
+    // Table of contents computed by the API from the anchored title elements (in document order).
+    _toc: {
+      type: 'array',
+      readOnly: true,
+      layout: 'none',
+      items: {
+        type: 'object',
+        required: ['id', 'title'],
+        properties: {
+          id: { type: 'string' },
+          title: { type: 'string' }
+        }
+      }
     }
   },
   $defs: {
@@ -211,7 +225,9 @@ export default {
       // This pattern is only a client-side validation.
       // The actual check is done on the API, which compares the input
       // with the result of slugify and returns an error if they differ.
-      pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$'
+      pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$',
+      errorMessage: 'Only lowercase letters, digits and dashes are allowed (e.g. my-page).',
+      'x-i18n-errorMessage': { fr: 'Uniquement des minuscules, chiffres et tirets (ex. ma-page).' }
     }
   }
 }

--- a/api/types/page-element-basics/schema.js
+++ b/api/types/page-element-basics/schema.js
@@ -67,11 +67,6 @@ export default {
           'x-i18n-title': { fr: 'Texte en gras' },
           layout: { cols: { xs: 6 } },
         },
-        link: {
-          $ref: 'https://github.com/data-fair/portals/common-links#/$defs/simpleLinkItem',
-          title: 'Configuration du lien',
-          layout: { comp: 'card' }
-        },
         icon: { $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/icon' },
         line: {
           type: 'object',
@@ -93,6 +88,53 @@ export default {
                 },
                 props: { background: true }
               }
+            }
+          }
+        },
+        link: {
+          $ref: 'https://github.com/data-fair/portals/common-links#/$defs/simpleLinkItem',
+          title: 'Configuration du lien',
+          layout: { comp: 'card' }
+        },
+        anchor: {
+          type: 'object',
+          title: 'Anchor & table of contents',
+          'x-i18n-title': { fr: 'Ancre & Sommaire' },
+          layout: {
+            comp: 'card',
+            children: [
+              'enabled',
+              { if: 'data?.enabled', children: ['inToc'] },
+              { if: 'data?.enabled && data?.inToc', children: ['label'] }
+            ]
+          },
+          properties: {
+            enabled: {
+              type: 'boolean',
+              title: 'Enable anchor',
+              'x-i18n-title': { fr: "Activer l'ancre" },
+              description: 'Lets visitors copy a direct link to this title.',
+              'x-i18n-description': { fr: 'Permet de copier un lien direct vers le titre.' },
+              layout: 'switch'
+            },
+            inToc: {
+              type: 'boolean',
+              title: 'Show in the table of contents',
+              'x-i18n-title': { fr: 'Afficher dans le sommaire' },
+              default: true,
+              layout: 'switch'
+            },
+            label: {
+              type: 'string',
+              title: 'Table of contents label',
+              'x-i18n-title': { fr: 'Libellé du sommaire' },
+              description: 'Optional shorter label shown in the table of contents instead of the title content.',
+              'x-i18n-description': { fr: 'Libellé plus court, optionnel, affiché dans le sommaire à la place du contenu du titre.' }
+            },
+            _slug: {
+              type: 'string',
+              readOnly: true,
+              layout: 'none'
             }
           }
         }

--- a/portal/app/app.vue
+++ b/portal/app/app.vue
@@ -65,6 +65,14 @@ useHead({
 </script>
 
 <style>
+/* Full-bleed banners break out to width:100vw, which includes the vertical
+   scrollbar width and would otherwise add a few px of horizontal overflow — a
+   thin gutter down the right edge, only visible once scrolled past the banner
+   (e.g. when landing on an anchor). Clip it here while keeping the full-bleed. */
+.v-application {
+  overflow-x: clip;
+}
+
 [tabindex="-1"]:focus {
   outline: none;
 }

--- a/portal/app/components/layout/layout-app-bar.vue
+++ b/portal/app/components/layout/layout-app-bar.vue
@@ -1,12 +1,7 @@
 <template>
-  <!--
-    Single app bar (header) with the navigation bar as its extension. Two
-    separate top app bars would overlap during SSR, as Vuetify only computes
-    their stacked top offset after mount. The `header` tag carries the single
-    `banner` landmark.
-  -->
   <component
     :is="preview ? VToolbar : VAppBar"
+    v-model="appBarActive"
     :color="headerConfig.show && headerConfig.color ? headerConfig.color : navBarConfig.color"
     :class="[
       (navBarConfig.transparent && scrolled) ? 'opacity-90' : undefined,
@@ -38,7 +33,7 @@ import { VToolbar, VAppBar } from 'vuetify/components'
 
 const { home } = defineProps<{ home?: boolean }>()
 const { portalConfig, preview } = usePortalStore()
-const { scrolled } = useNavigationStore()
+const { scrolled, appBarActive } = useNavigationStore()
 
 const headerConfig = computed(() => {
   if (!home || !portalConfig.value.headerHomeActive) return portalConfig.value.header

--- a/portal/app/components/layout/layout-app-bar.vue
+++ b/portal/app/components/layout/layout-app-bar.vue
@@ -1,17 +1,24 @@
 <template>
+  <!--
+    Single app bar (header) with the navigation bar as its extension. Two
+    separate top app bars would overlap during SSR, as Vuetify only computes
+    their stacked top offset after mount. The `header` tag carries the single
+    `banner` landmark.
+  -->
   <component
     :is="preview ? VToolbar : VAppBar"
     :color="headerConfig.show && headerConfig.color ? headerConfig.color : navBarConfig.color"
     :class="[
-      (navBarConfig.transparent && isScrolled) ? 'opacity-90' : undefined,
+      (navBarConfig.transparent && scrolled) ? 'opacity-90' : undefined,
       navBarConfig.color === 'background' ? 'header-border-inner' : undefined
     ]"
     :extension-height="64"
     :height="headerConfig.show ? 128 : 0"
     :scroll-behavior="scrollBehavior + ' elevate'"
     scroll-threshold="150"
+    tag="header"
   >
-    <!-- Header (128px)-->
+    <!-- Header (128px) -->
     <layout-header
       v-if="headerConfig.show"
       :header-config="headerConfig"
@@ -22,6 +29,7 @@
       <layout-nav-bar :nav-bar-config="navBarConfig" />
     </template>
   </component>
+
   <nav-drawer :navigation="portalConfig.menu.children" />
 </template>
 
@@ -30,19 +38,7 @@ import { VToolbar, VAppBar } from 'vuetify/components'
 
 const { home } = defineProps<{ home?: boolean }>()
 const { portalConfig, preview } = usePortalStore()
-const isScrolled = ref(false)
-
-onMounted(() => {
-  if (!preview) {
-    const updateScrollState = () => {
-      isScrolled.value = window.scrollY > 150
-    }
-    window.addEventListener('scroll', updateScrollState)
-    onBeforeUnmount(() => {
-      window.removeEventListener('scroll', updateScrollState)
-    })
-  }
-})
+const { scrolled } = useNavigationStore()
 
 const headerConfig = computed(() => {
   if (!home || !portalConfig.value.headerHomeActive) return portalConfig.value.header
@@ -54,14 +50,12 @@ const navBarConfig = computed(() => {
   return { ...portalConfig.value.navBar, ...portalConfig.value.navBarHome }
 })
 
+// `hide` slides the header out while keeping the extension (nav bar) pinned,
+// `fully-hide` slides both away, `default` keeps everything. The header hides
+// unless kept; the nav bar only hides when shown and neither bar is kept.
 const scrollBehavior = computed(() => {
-  if (headerConfig.value.show && !headerConfig.value.keepOnScroll && !navBarConfig.value.keepOnScroll) {
-    return 'fully-hide'
-  }
-  if (navBarConfig.value.keepOnScroll && headerConfig.value.show) {
-    return 'hide'
-  }
-  return 'default'
+  if (!headerConfig.value.show || headerConfig.value.keepOnScroll) return 'default'
+  return navBarConfig.value.keepOnScroll ? 'hide' : 'fully-hide'
 })
 
 </script>

--- a/portal/app/components/layout/layout-page.vue
+++ b/portal/app/components/layout/layout-page.vue
@@ -14,12 +14,16 @@
     </div>
   </v-main>
 
+  <!-- The table of contents only earns its place once hydrated, so it never renders during SSR. -->
+  <client-only>
+    <page-toc />
+  </client-only>
+
   <!-- Do not put bottom breadcrumbs in main, ensuring they stay just above the footer even when main content is short. -->
   <LayoutBreadcrumbs v-if="!isHome && showBottomBreadcrumbs" />
 </template>
 
 <script setup lang="ts">
-
 const { isFluid } = defineProps<{ isFluid?: boolean }>()
 
 const { portalConfig } = usePortalStore()

--- a/portal/app/components/layout/layout-title.vue
+++ b/portal/app/components/layout/layout-title.vue
@@ -1,12 +1,15 @@
 <template>
   <component
     :is="titleTag"
+    :id="anchorId"
     :class="[
       'd-flex align-center',
       element.centered ? 'justify-center' : undefined,
       element.bold ? 'font-weight-bold' : undefined,
-      `text-${element.titleSize || 'h3'}`
+      `text-${element.titleSize || 'h3'}`,
+      anchorId ? 'page-title--anchored' : undefined
     ]"
+    :style="anchorId ? 'scroll-margin-top: var(--toc-scroll-offset, 96px);' : undefined"
   >
     <!-- decorative <span>s instead of <v-divider>/<div> so the heading only contains phrasing content (HTML spec) -->
     <span
@@ -22,9 +25,18 @@
       size="small"
       class="mr-4"
     />
-    <span :class="['d-block', element.color ? `text-${element.color}` : undefined, element.centered ? 'text-center' : undefined]">
-      {{ element.content }}
-      <span
+    <span :class="['d-block', element.color ? `text-${element.color}` : undefined, element.centered ? 'text-center' : undefined]"><!--
+      -->{{ element.content }}<!-- keep the copy button inline so it follows the last line of a wrapping title --><v-btn
+        v-if="anchorId"
+        :icon="copied ? mdiCheck : mdiLinkVariant"
+        :title="copied ? t('linkCopied') : t('copyLink')"
+        :aria-label="copied ? t('linkCopied') : t('copyLink')"
+        variant="text"
+        density="comfortable"
+        size="small"
+        class="page-anchor-btn ml-1"
+        @click.prevent.stop="copyLink"
+      /><span
         v-if="element.line?.position === 'bottom-small' || element.line?.position === 'bottom-medium'"
         :class="['d-block mt-2', element.centered ? 'mx-auto' : undefined]"
         :style="{
@@ -46,12 +58,32 @@
 </template>
 
 <script setup lang="ts">
+import { mdiLinkVariant, mdiCheck } from '@mdi/js'
 import type { TitleElement } from '#api/types/page-elements/index.ts'
 
 const { element } = defineProps<{ element: TitleElement }>()
 
+const { t } = useI18n()
+
 const titleTag = computed(() => element.titleTag ?? element.titleSize ?? 'h3')
 
+const anchorId = computed(() => element.anchor?._slug || undefined)
+
+const copied = ref(false)
+let copiedTimeout: ReturnType<typeof setTimeout> | undefined
+const copyLink = async () => {
+  if (!anchorId.value) return
+  const url = `${window.location.origin}${window.location.pathname}#${anchorId.value}`
+  try {
+    await navigator.clipboard.writeText(url)
+    history.replaceState(null, '', '#' + anchorId.value)
+    copied.value = true
+    clearTimeout(copiedTimeout)
+    copiedTimeout = setTimeout(() => { copied.value = false }, 1500)
+  } catch { /* clipboard unavailable (insecure context) */ }
+}
+
+onUnmounted(() => clearTimeout(copiedTimeout))
 </script>
 
 <style scoped>
@@ -109,4 +141,23 @@ const titleTag = computed(() => element.titleTag ?? element.titleSize ?? 'h3')
 .font-weight-bold {
   font-weight: 700 !important;
 }
+/* Reveal the copy-anchor button only when hovering/focusing the anchored title */
+.page-anchor-btn {
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  vertical-align: middle;
+}
+.page-title--anchored:hover .page-anchor-btn,
+.page-anchor-btn:focus-visible {
+  opacity: 1;
+}
 </style>
+
+<i18n lang="yaml">
+  en:
+    copyLink: Copy link to this section
+    linkCopied: Link copied
+  fr:
+    copyLink: Copier le lien vers cette section
+    linkCopied: Lien copié
+</i18n>

--- a/portal/app/components/layout/page-toc.vue
+++ b/portal/app/components/layout/page-toc.vue
@@ -7,6 +7,7 @@
         color="transparent"
         location="left"
         tag="div"
+        :style="{ top: `${appBarBottom}px` }"
         permanent
         floating
       />
@@ -15,6 +16,7 @@
         :aria-label="t('tableOfContents')"
         color="transparent"
         location="right"
+        :style="{ top: `${appBarBottom}px` }"
         permanent
         floating
       >
@@ -37,6 +39,7 @@
       size="small"
       color="primary"
       location="top right"
+      :style="{ top: `${appBarBottom}px` }"
       app
       icon
     >
@@ -69,6 +72,7 @@ const { isFluid } = defineProps<{ isFluid?: boolean }>()
 
 const { t } = useI18n({ useScope: 'local' })
 const { lgAndUp } = useDisplay()
+const { appBarBottom } = useNavigationStore()
 
 const route = useRoute()
 

--- a/portal/app/components/layout/page-toc.vue
+++ b/portal/app/components/layout/page-toc.vue
@@ -70,16 +70,72 @@ const { isFluid } = defineProps<{ isFluid?: boolean }>()
 const { t } = useI18n({ useScope: 'local' })
 const { lgAndUp } = useDisplay()
 
+const route = useRoute()
+
 const pageConfig = inject<Ref<PageConfig | null>>('page-config')
 const sections = computed(() => pageConfig?.value?._toc ?? [])
 
+// Keep in sync with the scroll-margin-top applied to anchored titles in layout-title.vue
+const scrollOffset = 96
+
 const activeId = ref<string | null>(null)
+
+// Highlight the last section whose title has scrolled past the offset line.
+const findActiveId = () => {
+  const list = sections.value
+  const first = list[0]
+  const last = list[list.length - 1]
+  if (!first || !last) return
+  let current = first.id
+  let ready = false
+  for (let i = list.length - 1; i >= 0; i--) {
+    const section = list[i]!
+    const el = document.getElementById(section.id)
+    if (!el) continue
+    ready = true
+    if (el.getBoundingClientRect().top - scrollOffset - 4 <= 0) {
+      current = section.id
+      break
+    }
+  }
+  // At the bottom of the page the last section may never cross the offset line, so force it active.
+  const doc = document.documentElement
+  if (ready && window.scrollY + window.innerHeight >= doc.scrollHeight - 1) {
+    current = last.id
+  }
+  if (ready) activeId.value = current
+}
+
+let timeout: ReturnType<typeof setTimeout> | undefined
+const onScroll = () => {
+  clearTimeout(timeout)
+  timeout = setTimeout(findActiveId, 17)
+}
+
+onMounted(async () => {
+  window.addEventListener('scroll', onScroll, { passive: true })
+  findActiveId()
+
+  // Deep link: when arriving with an anchor in the URL, jump straight to that section.
+  const hash = route.hash.slice(1)
+  if (hash && sections.value.some(section => section.id === hash)) {
+    await nextTick()
+    document.getElementById(hash)?.scrollIntoView()
+    activeId.value = hash
+  }
+})
+
+onUnmounted(() => {
+  clearTimeout(timeout)
+  window.removeEventListener('scroll', onScroll)
+})
 
 const goToSection = (id: string) => {
   const el = document.getElementById(id)
   if (!el) return
   el.scrollIntoView({ behavior: 'smooth' })
   history.replaceState(history.state, '', '#' + id)
+  activeId.value = id
 }
 
 </script>

--- a/portal/app/components/layout/page-toc.vue
+++ b/portal/app/components/layout/page-toc.vue
@@ -1,0 +1,92 @@
+<template>
+  <template v-if="sections.length">
+    <template v-if="lgAndUp && !isFluid">
+      <!-- Empty left drawer to keep the content centered -->
+      <v-navigation-drawer
+        aria-hidden="true"
+        color="transparent"
+        location="left"
+        tag="div"
+        permanent
+        floating
+      />
+
+      <v-navigation-drawer
+        :aria-label="t('tableOfContents')"
+        color="transparent"
+        location="right"
+        permanent
+        floating
+      >
+        <v-sheet
+          color="background"
+          class="rounded-bs-md"
+        >
+          <toc-list
+            :sections="sections"
+            :active-id="activeId"
+            @select="goToSection"
+          />
+        </v-sheet>
+      </v-navigation-drawer>
+    </template>
+
+    <!-- Smaller screens / full-width pages: the table of contents collapses into a menu -->
+    <v-fab
+      v-else
+      size="small"
+      color="primary"
+      location="top right"
+      app
+      icon
+    >
+      <v-icon :icon="mdiTableOfContents"/>
+      <v-menu
+        activator="parent"
+        :close-on-content-click="false"
+      >
+        <v-card
+          max-width="340"
+          class="mt-2"
+        >
+          <toc-list
+            :sections="sections"
+            :active-id="activeId"
+            @select="goToSection"
+          />
+        </v-card>
+      </v-menu>
+    </v-fab>
+  </template>
+</template>
+
+<script setup lang="ts">
+import { useDisplay } from 'vuetify'
+import { mdiTableOfContents } from '@mdi/js'
+import type { PageConfig } from '#api/types/page'
+
+const { isFluid } = defineProps<{ isFluid?: boolean }>()
+
+const { t } = useI18n({ useScope: 'local' })
+const { lgAndUp } = useDisplay()
+
+const pageConfig = inject<Ref<PageConfig | null>>('page-config')
+const sections = computed(() => pageConfig?.value?._toc ?? [])
+
+const activeId = ref<string | null>(null)
+
+const goToSection = (id: string) => {
+  const el = document.getElementById(id)
+  if (!el) return
+  el.scrollIntoView({ behavior: 'smooth' })
+  history.replaceState(history.state, '', '#' + id)
+}
+
+</script>
+
+<i18n lang="yaml">
+fr:
+  tableOfContents: Sommaire
+en:
+  tableOfContents: Table of contents
+</i18n>

--- a/portal/app/components/layout/toc-list.vue
+++ b/portal/app/components/layout/toc-list.vue
@@ -1,0 +1,39 @@
+<template>
+  <v-list
+    bg-color="transparent"
+    density="compact"
+    color="primary"
+    class="py-2"
+    nav
+  >
+    <v-list-subheader>{{ t('tableOfContents') }}</v-list-subheader>
+
+    <v-list-item
+      v-for="section in sections"
+      :key="section.id"
+      :active="activeId === section.id"
+      @click="emit('select', section.id)"
+    >
+      <!-- text-wrap lets long titles wrap instead of being truncated (the portals_v1 regression) -->
+      <v-list-item-title class="text-wrap">{{ section.title }}</v-list-item-title>
+    </v-list-item>
+  </v-list>
+</template>
+
+<script setup lang="ts">
+import type { PageConfig } from '#api/types/page'
+
+type TocSection = NonNullable<PageConfig['_toc']>[number]
+
+defineProps<{ sections: TocSection[], activeId: string | null }>()
+const emit = defineEmits<{ select: [id: string] }>()
+
+const { t } = useI18n({ useScope: 'local' })
+</script>
+
+<i18n lang="yaml">
+fr:
+  tableOfContents: Sommaire
+en:
+  tableOfContents: Table of contents
+</i18n>

--- a/portal/app/components/nav/nav-drawer-item.vue
+++ b/portal/app/components/nav/nav-drawer-item.vue
@@ -2,7 +2,6 @@
   <!-- Level 1: direct link -->
   <template v-if="level === 1 && item.type !== 'submenu'">
     <v-list-item
-      :title="resolveLinkTitle(item, locale)"
       :to="!isExternalLink(item) ? resolveLink(item) : undefined"
       :href="isExternalLink(item) ? resolveLink(item) : undefined"
       :target="item.type === 'external' && item.target ? '_blank' : undefined"
@@ -16,6 +15,8 @@
           :color="item.icon.color"
         />
       </template>
+      <!-- text-wrap lets long titles wrap instead of being truncated -->
+      <v-list-item-title class="text-wrap">{{ resolveLinkTitle(item, locale) }}</v-list-item-title>
     </v-list-item>
   </template>
 
@@ -45,7 +46,6 @@
   <!-- Level 2+: direct link -->
   <template v-else-if="level >= 2 && item.type !== 'submenu'">
     <v-list-item
-      :title="resolveLinkTitle(item, locale)"
       :to="!isExternalLink(item) ? resolveLink(item) : undefined"
       :href="isExternalLink(item) ? resolveLink(item) : undefined"
       :target="item.type === 'external' && item.target ? '_blank' : undefined"
@@ -59,6 +59,8 @@
           :color="item.icon.color"
         />
       </template>
+      <!-- text-wrap lets long titles wrap instead of being truncated -->
+      <v-list-item-title class="text-wrap">{{ resolveLinkTitle(item, locale) }}</v-list-item-title>
     </v-list-item>
   </template>
 
@@ -71,7 +73,6 @@
       <template #activator="{ props: activatorProps }">
         <v-list-item
           v-bind="activatorProps"
-          :title="item.title"
           :active="isActive"
         >
           <template #prepend>
@@ -81,6 +82,8 @@
               :color="item.icon.color"
             />
           </template>
+          <!-- text-wrap lets long titles wrap instead of being truncated -->
+          <v-list-item-title class="text-wrap">{{ item.title }}</v-list-item-title>
         </v-list-item>
       </template>
       <nav-drawer-item

--- a/portal/app/components/nav/nav-drawer.vue
+++ b/portal/app/components/nav/nav-drawer.vue
@@ -3,6 +3,7 @@
     id="nav-drawer"
     v-model="drawer"
     :aria-label="t('mobileNavigation')"
+    :style="{ top: `${appBarBottom}px` }"
     temporary
   >
     <v-list
@@ -26,7 +27,7 @@ import type { MenuItem } from '#api/types/portal'
 defineProps<{ navigation: MenuItem[] }>()
 
 const { t } = useI18n()
-const { drawer } = useNavigationStore()
+const { drawer, appBarBottom } = useNavigationStore()
 
 // When the drawer opens, move focus into the drawer so users don't have to tab out
 // of the header first. v-navigation-drawer traps focus but does not auto-focus content.

--- a/portal/app/components/nav/nav-tabs-or-drawer.vue
+++ b/portal/app/components/nav/nav-tabs-or-drawer.vue
@@ -1,8 +1,15 @@
 <template>
+  <!--
+    min-width:0 lets this flex item shrink below the tabs' content width.
+    Without it v-tabs stretches the navbar (and gets clipped) instead of
+    overflowing internally, which is what makes Vuetify flag the slide group as
+    overflowing and triggers the swap to the drawer.
+  -->
   <div
     id="header-navigation"
     tabindex="-1"
     class="d-flex flex-grow-1 h-100"
+    style="min-width: 0"
   >
     <!-- Smaller screens: navigation in drawer -->
     <nav-drawer-activator v-if="$vuetify.display.smAndDown || tabsOverflowing" />

--- a/portal/app/components/nav/nav-tabs-or-drawer.vue
+++ b/portal/app/components/nav/nav-tabs-or-drawer.vue
@@ -1,10 +1,4 @@
 <template>
-  <!--
-    min-width:0 lets this flex item shrink below the tabs' content width.
-    Without it v-tabs stretches the navbar (and gets clipped) instead of
-    overflowing internally, which is what makes Vuetify flag the slide group as
-    overflowing and triggers the swap to the drawer.
-  -->
   <div
     id="header-navigation"
     tabindex="-1"

--- a/portal/app/components/page-element/layout/page-element-banner.vue
+++ b/portal/app/components/page-element/layout/page-element-banner.vue
@@ -46,7 +46,6 @@ const { preview } = usePortalStore()
 const getPageImageSrc = usePageImageSrc()
 // If breadcrumbs are displayed and the banner is at the top, don't apply the negative margin.
 const { showTopBreadcrumbs } = useNavigationStore()
-// const pageConfig = inject<Ref<PageConfig>>('page-config')
 
 </script>
 

--- a/portal/app/composables/use-navigation-store.ts
+++ b/portal/app/composables/use-navigation-store.ts
@@ -26,6 +26,11 @@ const createNavigationStore = (options: NavigationStoreOptions) => {
     onScopeDispose(() => window.removeEventListener('scroll', onScroll))
   }
 
+  // Whether the app bar currently shows its full height. Bound to VAppBar's
+  // model value (layout-app-bar), so it mirrors Vuetify's own scroll state: the
+  // header re-appears when scrolling up, not merely below a scroll threshold.
+  const appBarActive = ref(true)
+
   // Y offset (px) where the navigation bar ends — where app-positioned children
   // (TOC drawer/FAB, navigation drawer) should start. Vuetify collapses
   // --v-layout-top to 0 when the header hides even though the nav bar stays
@@ -38,10 +43,9 @@ const createNavigationStore = (options: NavigationStoreOptions) => {
     const header = (isHome && config.headerHomeActive) ? { ...config.header, ...config.headerHome } : config.header
     const navBar = (isHome && config.navBarHomeActive) ? { ...config.navBar, ...config.navBarHome } : config.navBar
     const full = (header.show ? 128 : 0) + 64
-    if (!scrolled.value) return full
-    // Scrolled: the header hides unless it is kept.
-    if (!header.show || header.keepOnScroll) return full
-    // The header is hidden; the navigation bar stays unless it also hides.
+    // The app bar shows its full height, so children sit below the whole bar.
+    if (appBarActive.value) return full
+    // Hidden on scroll: the navigation bar stays pinned with `hide`, everything slides away with `fully-hide`.
     return navBar.keepOnScroll ? 64 : 0
   })
 
@@ -237,6 +241,7 @@ const createNavigationStore = (options: NavigationStoreOptions) => {
     setShowBreadcrumbs,
     isIframe,
     scrolled,
+    appBarActive,
     appBarBottom
   }
 }

--- a/portal/app/composables/use-navigation-store.ts
+++ b/portal/app/composables/use-navigation-store.ts
@@ -17,6 +17,34 @@ const createNavigationStore = (options: NavigationStoreOptions) => {
   const isIframe = options.isIframe
   const showBreadcrumbsOverride = ref<boolean | undefined>(undefined) // Store if page config overrides portal breadcrumb visibility
 
+  // Scrolled past the app bar threshold (mirrors layout-app-bar's
+  // scroll-threshold). Drives the app bar transparency and the drawer offset.
+  const scrolled = ref(false)
+  if (import.meta.client) {
+    const onScroll = () => { scrolled.value = window.scrollY > 150 }
+    window.addEventListener('scroll', onScroll, { passive: true })
+    onScopeDispose(() => window.removeEventListener('scroll', onScroll))
+  }
+
+  // Y offset (px) where the navigation bar ends — where app-positioned children
+  // (TOC drawer/FAB, navigation drawer) should start. Vuetify collapses
+  // --v-layout-top to 0 when the header hides even though the nav bar stays
+  // visible, so we derive the offset ourselves.
+  const route = useRoute()
+  const appBarBottom = computed(() => {
+    if (isIframe.value) return 0
+    const isHome = route.path === '/'
+    const config = $portal.config
+    const header = (isHome && config.headerHomeActive) ? { ...config.header, ...config.headerHome } : config.header
+    const navBar = (isHome && config.navBarHomeActive) ? { ...config.navBar, ...config.navBarHome } : config.navBar
+    const full = (header.show ? 128 : 0) + 64
+    if (!scrolled.value) return full
+    // Scrolled: the header hides unless it is kept.
+    if (!header.show || header.keepOnScroll) return full
+    // The header is hidden; the navigation bar stays unless it also hides.
+    return navBar.keepOnScroll ? 64 : 0
+  })
+
   // Emit BreadcrumbList JSON-LD from resolved breadcrumbs (SSR only)
   if (import.meta.server) {
     const origin = useRequestURL().origin
@@ -207,7 +235,9 @@ const createNavigationStore = (options: NavigationStoreOptions) => {
     showTopBreadcrumbs,
     showBottomBreadcrumbs,
     setShowBreadcrumbs,
-    isIframe
+    isIframe,
+    scrolled,
+    appBarBottom
   }
 }
 

--- a/tests/features/pages/pages.api.spec.ts
+++ b/tests/features/pages/pages.api.spec.ts
@@ -18,8 +18,9 @@ test.describe('pages management', () => {
     const pageConfig = { title: 'My page', elements: [] }
     const page = (await user1.post('/api/pages', { type: 'home', config: pageConfig })).data
     assert.equal(page.owner.id, 'test_admin')
-    assert.deepEqual(page.config, pageConfig)
-    assert.deepEqual(page.draftConfig, pageConfig)
+    // the API attaches a computed table of contents (empty here, no anchored titles)
+    assert.deepEqual(page.config, { ...pageConfig, _toc: [] })
+    assert.deepEqual(page.draftConfig, { ...pageConfig, _toc: [] })
   })
 
   test('should duplicate a page with an image', async () => {
@@ -128,5 +129,56 @@ test.describe('staging publication flow', () => {
     const requested = (await orgContrib.patch(`/api/pages/${page._id}`, { requestedPortals: [portal._id] })).data
     assert.deepEqual(requested.requestedPortals, [portal._id])
     assert.deepEqual(requested.portals, [])
+  })
+
+  test('generates and deduplicates title anchor slugs from the content', async () => {
+    const page = (await user1.post('/api/pages', { type: 'generic', title: 'P', config: { title: 'P', elements: [], genericMetadata: { slug: 'p' } } })).data
+    const titleElement = (content: string) => ({ type: 'title', titleSize: 'h2', content, anchor: { enabled: true } })
+    const patchElements = (elements: any[]) => user1.patch(`/api/pages/${page._id}`, { draftConfig: { title: 'P', elements, genericMetadata: { slug: 'p' } } })
+
+    // the slug is generated from the title content
+    const single = (await patchElements([titleElement('Mon Ancre')])).data
+    assert.equal(single.draftConfig.elements[0].anchor._slug, 'mon-ancre')
+
+    // duplicating a title (same content) deduplicates the generated slug in document order
+    const dup = (await patchElements([titleElement('Intro'), titleElement('Intro')])).data
+    assert.equal(dup.draftConfig.elements[0].anchor._slug, 'intro')
+    assert.equal(dup.draftConfig.elements[1].anchor._slug, 'intro-2')
+
+    // a disabled anchor gets no slug
+    const disabled = (await patchElements([{ type: 'title', titleSize: 'h2', content: 'Plain', anchor: { enabled: false } }])).data
+    assert.equal(disabled.draftConfig.elements[0].anchor._slug, undefined)
+  })
+
+  test('builds the table of contents from anchored titles, including nested ones, in order', async () => {
+    const page = (await user1.post('/api/pages', { type: 'generic', title: 'P', config: { title: 'P', elements: [], genericMetadata: { slug: 'p' } } })).data
+
+    const elements = [
+      { type: 'title', titleSize: 'h2', content: 'Introduction', anchor: { enabled: true, inToc: true } },
+      // an anchored title is not added to the table of contents when inToc is off
+      { type: 'title', titleSize: 'h3', content: 'Anchor without toc', anchor: { enabled: true, inToc: false } },
+      { type: 'title', titleSize: 'h3', content: 'No anchor' },
+      {
+        type: 'two-columns',
+        disposition: 'equal',
+        gutter: 'default',
+        children: [{ type: 'title', titleSize: 'h4', content: 'In a column', anchor: { enabled: true, inToc: true } }],
+        children2: [{ type: 'text', content: 'lorem' }]
+      },
+      // the label overrides the displayed title in the table of contents
+      { type: 'title', titleSize: 'h2', content: 'Conclusion', anchor: { enabled: true, inToc: true, label: 'The end' } }
+    ]
+    const updated = (await user1.patch(`/api/pages/${page._id}`, { draftConfig: { title: 'P', elements, genericMetadata: { slug: 'p' } } })).data
+
+    assert.deepEqual(updated.draftConfig._toc, [
+      { id: 'introduction', title: 'Introduction' },
+      { id: 'in-a-column', title: 'In a column' },
+      { id: 'conclusion', title: 'The end' }
+    ])
+
+    // publishing the draft carries the computed table of contents over to the published config
+    await user1.post(`/api/pages/${page._id}/draft`)
+    const validated = (await user1.get(`/api/pages/${page._id}`)).data
+    assert.deepEqual(validated.config._toc, updated.draftConfig._toc)
   })
 })

--- a/tests/features/portal-rendering/page-toc.e2e.spec.ts
+++ b/tests/features/portal-rendering/page-toc.e2e.spec.ts
@@ -123,5 +123,23 @@ test.describe('content page table of contents', () => {
         return Math.round(nav.getBoundingClientRect().top - ext.getBoundingClientRect().bottom)
       })
     }, { timeout: 15_000 }).toBeGreaterThanOrEqual(0)
+
+    // Scrolling back up re-reveals the whole header: Vuetify's `hide` behaviour reacts to the
+    // scroll direction, so a continuous upward gesture keeps the header shown even while still
+    // past the threshold. The table of contents must follow the revealed header down to the full
+    // bar height instead of staying pinned high and slipping underneath it.
+    await page.mouse.move(720, 450)
+    for (let i = 0; i < 20; i++) await page.mouse.wheel(0, 60) // scroll well past the header so it hides
+    await expect.poll(async () => {
+      await page.mouse.wheel(0, -40) // keep scrolling up so the header stays revealed
+      return page.evaluate(() => {
+        const bar = document.querySelector('.v-app-bar')
+        const nav = document.querySelector('nav[aria-label="Sommaire"]')
+        if (!bar || !nav) return null
+        if (window.scrollY <= 170) return null // only assert inside the bug window: still past the threshold
+        if (Math.round(bar.getBoundingClientRect().bottom) < 190) return null // and with the header actually revealed
+        return Math.round(nav.getBoundingClientRect().top)
+      })
+    }, { timeout: 15_000 }).toBeGreaterThanOrEqual(190)
   })
 })

--- a/tests/features/portal-rendering/page-toc.e2e.spec.ts
+++ b/tests/features/portal-rendering/page-toc.e2e.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '../../fixtures/portal.ts'
+import { axiosAuth, clean } from '../../support/axios.ts'
+
+const user1 = await axiosAuth('test_admin@test.com')
+
+const html = (n: number) => Array.from({ length: n }, (_, i) =>
+  `<p>Paragraphe ${i + 1}. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>`
+).join('')
+const text = (uuid: string, n: number) => ({ uuid, type: 'text', content: 'lorem', _html: html(n) })
+
+test.describe('content page table of contents', () => {
+  test.beforeEach(clean)
+
+  test('lists anchored titles, links them, and exposes copiable anchors', async ({ page, goToPortal }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    const portal = (await user1.post('/api/portals', {
+      config: { title: 'TOC Portal', menu: { children: [] }, agentChat: { active: false } }
+    })).data
+    const createdPage = (await user1.post('/api/pages', {
+      type: 'generic',
+      config: {
+        title: 'Documentation',
+        elements: [
+          { uuid: 't1', type: 'title', content: 'Introduction', titleSize: 'h2', titleTag: 'h2', anchor: { enabled: true, inToc: true } },
+          text('x1', 6),
+          { uuid: 't2', type: 'title', content: 'Paramètres avancés', titleSize: 'h3', titleTag: 'h3', anchor: { enabled: true, inToc: true } },
+          text('x2', 6),
+          { uuid: 't3', type: 'title', content: 'Section sans ancre', titleSize: 'h3', titleTag: 'h3' },
+          text('x3', 6),
+          {
+            uuid: 'c1',
+            type: 'two-columns',
+            disposition: 'equal',
+            gutter: 'default',
+            children: [{ uuid: 't4', type: 'title', content: 'Titre dans une colonne', titleSize: 'h4', titleTag: 'h4', anchor: { enabled: true, inToc: true } }],
+            children2: [text('x4', 2)]
+          },
+          { uuid: 't5', type: 'title', content: 'Conclusion', titleSize: 'h2', titleTag: 'h2', anchor: { enabled: true, inToc: true, label: 'Fin' } },
+          text('x5', 6)
+        ]
+      },
+      portals: [portal._id],
+      owner: portal.owner
+    })).data
+
+    await goToPortal(portal._id, `/pages/${createdPage.config.genericMetadata.slug}`)
+
+    // the table of contents renders as a navigation landmark (Vuetify navigation-drawer => <nav>)
+    const toc = page.getByRole('navigation', { name: 'Sommaire' })
+    await expect(toc.getByText('Sommaire')).toBeVisible({ timeout: 15_000 })
+
+    // only anchored titles are listed (including the one nested in two-columns), with the label override
+    await expect(toc.getByText('Introduction')).toBeVisible()
+    await expect(toc.getByText('Paramètres avancés')).toBeVisible()
+    await expect(toc.getByText('Titre dans une colonne')).toBeVisible()
+    await expect(toc.getByText('Fin')).toBeVisible()
+    await expect(toc.getByText('Section sans ancre')).toHaveCount(0)
+
+    // anchored headings expose a slugified id; the non-anchored one does not
+    await expect(page.locator('h3#parametres-avances')).toBeVisible()
+    await expect(page.locator('main h3', { hasText: 'Section sans ancre' })).not.toHaveAttribute('id')
+
+    // the copy button carries a native title for accessibility (RGAA)
+    await expect(page.locator('#introduction button.page-anchor-btn'))
+      .toHaveAttribute('title', 'Copier le lien vers cette section')
+
+    // clicking a TOC entry writes the anchor to the URL (re-click until the page is hydrated)
+    await expect.poll(async () => {
+      await toc.locator('.v-list-item', { hasText: 'Paramètres avancés' }).click()
+      return page.evaluate(() => location.hash)
+    }, { timeout: 15_000 }).toBe('#parametres-avances')
+  })
+})

--- a/tests/features/portal-rendering/page-toc.e2e.spec.ts
+++ b/tests/features/portal-rendering/page-toc.e2e.spec.ts
@@ -71,4 +71,57 @@ test.describe('content page table of contents', () => {
       return page.evaluate(() => location.hash)
     }, { timeout: 15_000 }).toBe('#parametres-avances')
   })
+
+  // The header and navigation bar are a single app bar (header + extension), not two
+  // stacked app bars: Vuetify only offsets stacked app bars after mount, so two of them
+  // overlap during SSR. The table of contents must also stay below the navigation bar
+  // when the header hides on scroll, even though Vuetify collapses --v-layout-top to 0.
+  test('keeps the table of contents below the navigation bar when the header hides on scroll', async ({ page, goToPortal }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    const portal = (await user1.post('/api/portals', {
+      config: {
+        title: 'TOC Portal',
+        menu: { children: [] },
+        agentChat: { active: false },
+        header: { show: true, showTitle: true, logoPrimaryType: 'hidden', keepOnScroll: false },
+        navBar: { keepOnScroll: true }
+      }
+    })).data
+    const createdPage = (await user1.post('/api/pages', {
+      type: 'generic',
+      config: {
+        title: 'Documentation',
+        elements: [
+          { uuid: 't1', type: 'title', content: 'Introduction', titleSize: 'h2', titleTag: 'h2', anchor: { enabled: true, inToc: true } },
+          text('x1', 30),
+          { uuid: 't2', type: 'title', content: 'Conclusion', titleSize: 'h2', titleTag: 'h2', anchor: { enabled: true, inToc: true } },
+          text('x2', 30)
+        ]
+      },
+      portals: [portal._id],
+      owner: portal.owner
+    })).data
+
+    await goToPortal(portal._id, `/pages/${createdPage.config.genericMetadata.slug}`)
+
+    const toc = page.getByRole('navigation', { name: 'Sommaire' })
+    await expect(toc.getByText('Sommaire')).toBeVisible({ timeout: 15_000 })
+
+    // A single app bar with an extension, never two stacked app bars (which overlap at SSR).
+    expect(await page.locator('.v-app-bar').count()).toBe(1)
+    await expect(page.locator('.v-app-bar .v-toolbar__extension')).toBeVisible()
+
+    // Once the header has hidden on scroll, the table of contents must stay below the
+    // still-visible navigation bar, not slip underneath it.
+    await expect.poll(async () => {
+      await page.evaluate(() => window.scrollTo(0, 600))
+      return page.evaluate(() => {
+        const ext = document.querySelector('.v-toolbar__extension')
+        const nav = document.querySelector('nav[aria-label="Sommaire"]')
+        if (!ext || !nav) return null
+        return Math.round(nav.getBoundingClientRect().top - ext.getBoundingClientRect().bottom)
+      })
+    }, { timeout: 15_000 }).toBeGreaterThanOrEqual(0)
+  })
 })

--- a/ui/src/composables/use-navigation-store.ts
+++ b/ui/src/composables/use-navigation-store.ts
@@ -52,7 +52,10 @@ export const useNavigationStore = () => {
     resolveLinkTitle,
     drawer: ref(false),
     personalDrawer: ref(false),
-    isIframe: ref(false)
+    isIframe: ref(false),
+    scrolled: ref(false),
+    // Preview is never scrolled, so the offset stays the full header + navigation bar height.
+    appBarBottom: ref(192)
   }
 }
 

--- a/ui/src/composables/use-navigation-store.ts
+++ b/ui/src/composables/use-navigation-store.ts
@@ -54,7 +54,8 @@ export const useNavigationStore = () => {
     personalDrawer: ref(false),
     isIframe: ref(false),
     scrolled: ref(false),
-    // Preview is never scrolled, so the offset stays the full header + navigation bar height.
+    // Preview keeps the app bar fully shown, so the offset stays the full header + navigation bar height.
+    appBarActive: ref(true),
     appBarBottom: ref(192)
   }
 }


### PR DESCRIPTION
Add title anchors and a content-page table of contents to the portal.

- Per-title anchor: setting a slug makes the title copiable (hover copy-link button with a native `title`, RGAA) and gives the heading a stable id; the URL hash is set on click and scrolled to on load (header offset handled via `scroll-margin-top`)
- Opt-in table of contents: an anchored title is listed in the page's table of contents only when its "show in the table of contents" toggle is enabled, with an optional shorter label overriding the displayed title
- Table of contents rendering: navigation drawer top-right on lg+, collapses to a button + dropdown menu otherwise; hidden on full-width pages; shown only when at least one anchored title opts in
- Header and navigation bar stay a single app bar (the navigation bar is its extension) so they don't overlap during SSR; the table of contents, its FAB and the navigation drawer are positioned below the navigation bar even when the header hides on scroll, the offset being derived manually since Vuetify collapses `--v-layout-top` to 0 in that case
- `config._toc` is computed server-side from the opted-in anchored titles in document order, reusing the shared element traversal so titles nested in columns or catalog blocks are included; anchor slugs are validated server-side (canonical format + unique per page)
- Long titles wrap instead of being truncated (portals_v1 regression)
- API and e2e tests (slug validation, recursive collection of opted-in titles, navigation-drawer rendering, copy anchors, single app bar kept below which the table of contents stays on scroll)

**Why:** a standing TODO to let a title block carry an anchor and to display a navigable table of contents on content pages.

**Heads-up:**
- `layout-page.vue` is a shared layout used by many pages — the table of contents renders only when at least one title opts into it, otherwise the layout is unchanged.
- `_toc` is computed on create/patch only, so existing pages show no table of contents until their next edit + publish (the portal degrades gracefully via `_toc ?? []`). No backfill migration is included.
