### PR TITLE
fix(ui): scope reuse-submit notifications by department

### DIFF
--- a/ui/src/components/reuses-actions.vue
+++ b/ui/src/components/reuses-actions.vue
@@ -80,8 +80,10 @@ const showNotifMenu = ref(false)
 const eventsSubscribeUrl = computed(() => {
   const topics = [{ key: 'reuses:reuse-submit', title: t('reuseSubmittedForValidation') }]
   const urlTemplate = window.parent.location.origin + '/data-fair/reuses/{reuseId}'
-  const sender = encodeURIComponent(`${session.state.account.type}:${session.state.account.id}:*`)
-  return `/events/embed/subscribe?key=${encodeURIComponent(topics.map(t => t.key).join(','))}&title=${encodeURIComponent(topics.map(t => t.title).join(','))}&url-template=${encodeURIComponent(urlTemplate)}&sender=${sender}&register=false`
+  let sender = `${session.state.account.type}:${session.state.account.id}`
+  if (session.state.account.department) sender += ':' + session.state.account.department
+  else sender += ':*'
+  return `/events/embed/subscribe?key=${encodeURIComponent(topics.map(t => t.key).join(','))}&title=${encodeURIComponent(topics.map(t => t.title).join(','))}&url-template=${encodeURIComponent(urlTemplate)}&sender=${encodeURIComponent(sender)}&register=false`
 })
 
 </script>

--- a/ui/src/pages/embed/reuses.vue
+++ b/ui/src/pages/embed/reuses.vue
@@ -28,6 +28,7 @@
           color="primary"
           class="mb-4"
           :loading="createReuse.loading.value"
+          :disabled="!!editingReuseId"
           @click="createReuse.execute()"
         >
           {{ t('createNew') }}


### PR DESCRIPTION
- Root accounts subscribe with `:*` and receive reuse submissions from every portal of the organization (root + departments).
- A department-scoped account only subscribes to its own department, avoiding cross-department leakage.

**Why:** possible now that the events service matches the `:*` wildcard on the subscription side. Emission already carried the portal's real department.

**Heads-up:** an events subscription's identity includes the `sender` string; switching from `:*` to `:department` creates a new subscription and orphans the old one. Existing subscribers will need to re-subscribe.
