### PR TITLE
feat(portal): show source data update date on application page

### DIFF
--- a/portal/app/components/application/application-metadata.vue
+++ b/portal/app/components/application/application-metadata.vue
@@ -36,6 +36,18 @@
         </div>
       </v-col>
 
+      <!-- Data update date -->
+      <v-col
+        v-if="dataUpdatedAt"
+        v-bind="metadataColProps"
+      >
+        {{ t('dataUpdatedAt') }} {{ dayjs(dataUpdatedAt).format('LL') }}
+      </v-col>
+
+      <v-col v-bind="metadataColProps">
+        {{ t('updatedAt') }} {{ dayjs(application.updatedAt).format('LL') }}
+      </v-col>
+
       <!-- Share (location not right)-->
       <ClientOnly>
         <v-col
@@ -84,10 +96,6 @@
         <!-- TODO: Show applications attachments ? (not implemented in V1) -->
       </v-col>
 
-      <v-col v-bind="metadataColProps">
-        {{ t('updatedAt') }} {{ dayjs(application.updatedAt).format('LL') }}
-      </v-col>
-
       <ClientOnly>
         <v-col v-if="application.public && metadataConfig.location === 'right'">
           {{ t('share') }}
@@ -103,7 +111,7 @@ import type { Application } from '#api/types/index.ts'
 import OwnerAvatar from '@data-fair/lib-vuetify/owner-avatar.vue'
 import { mdiFullscreen } from '@mdi/js'
 
-const { application } = defineProps<{ application: Application }>()
+const { application } = defineProps<{ application: Application, dataUpdatedAt?: string }>()
 const { portalConfig } = usePortalStore()
 const { t } = useI18n()
 const { dayjs } = useLocaleDayjs()
@@ -131,7 +139,8 @@ const customOwnerLabel = portalConfig.value.labelsOverrides?.owner
     share: 'Share:'
     text: Fullscreen
     tooltip: Open the application in full page
-    updatedAt: Updated at
+    dataUpdatedAt: Data updated at
+    updatedAt: Visualization updated at
   fr:
     application: 'Application :'
     owner: 'Propriétaire :'
@@ -139,5 +148,6 @@ const customOwnerLabel = portalConfig.value.labelsOverrides?.owner
     share: 'Partager :'
     text: Plein écran
     tooltip: Ouvrir la visualisation en pleine page
-    updatedAt: Mise à jour le
+    dataUpdatedAt: Données mises à jour le
+    updatedAt: Visualisation mise à jour le
 </i18n>

--- a/portal/app/components/dataset/dataset-metadata.vue
+++ b/portal/app/components/dataset/dataset-metadata.vue
@@ -159,11 +159,11 @@
         </div>
       </v-col>
 
-      <!-- Modified or dataUpdatedAt -->
+      <!-- Last update date -->
       <v-col v-bind="metadataColProps">
-        <div class="text-body-small text-medium-emphasis">{{ metadataLabel('modified') }}</div>
+        <div class="text-body-small text-medium-emphasis">{{ dataset.modified || dataset.dataUpdatedAt ? metadataLabel('modified') : t('lastUpdate') }}</div>
         <div class="d-flex align-center ga-2">
-          {{ dayjs(dataset.modified || dataset.dataUpdatedAt).format('LL') }}
+          {{ dayjs(dataset.modified || dataset.dataUpdatedAt || dataset.updatedAt).format('LL') }}
         </div>
       </v-col>
 
@@ -350,6 +350,7 @@ const metadataLabel = (key: keyof BaseMetadataSettings) => metadataSettings.data
       weekly: 'Every week'
     conformsTo: 'Schema:'
     keywords: 'Keywords:'
+    lastUpdate: 'Last update:'
     license: 'License:'
     modified: 'Data last modified:'
     newWindow: 'New window'
@@ -397,6 +398,7 @@ const metadataLabel = (key: keyof BaseMetadataSettings) => metadataSettings.data
       weekly: 'Chaque semaine'
     conformsTo: 'Schéma :'
     keywords: 'Mots-clés :'
+    lastUpdate: 'Dernière mise à jour :'
     license: 'Licence :'
     modified: 'Dernière mise à jour des données :'
     newWindow: 'Nouvelle fenêtre'

--- a/portal/app/pages/applications/[ref]/index.vue
+++ b/portal/app/pages/applications/[ref]/index.vue
@@ -50,7 +50,10 @@
           :order-md="portalConfig.applications.page.metadata?.location === 'top' ? 'first' : 1"
           cols="12"
         >
-          <application-metadata :application="application" />
+          <application-metadata
+            :application="application"
+            :data-updated-at="dataUpdatedAt"
+          />
         </v-col>
       </v-row>
 
@@ -151,7 +154,7 @@ const datasetsUrl = computed(() => {
   const datasetsIds = appConfigFetch.data.value?.datasets?.map(d => d.id || d.href.split('/').pop())
   if (!datasetsIds || datasetsIds.length === 0) return ''
   return withQuery('/data-fair/api/v1/datasets', {
-    select: 'id,slug,title,summary,description,updatedAt,dataUpdatedAt,extras,bbox,topics,keywords,image,isMetaOnly,owner,-userPermissions',
+    select: 'id,slug,title,summary,description,updatedAt,dataUpdatedAt,modified,extras,bbox,topics,keywords,image,isMetaOnly,owner,-userPermissions',
     size: 100,
     html: 'vuetify',
     ids: datasetsIds.join(','),
@@ -159,6 +162,14 @@ const datasetsUrl = computed(() => {
 })
 const datasetsFetch = useLocalFetch<{ count: number, results: Dataset[] }>(datasetsUrl)
 const datasets = computed(() => datasetsFetch.data.value?.results || [])
+// Most recent data update among source datasets (matches data-fair's _modified fallback: modified > dataUpdatedAt)
+const dataUpdatedAt = computed(() => {
+  const dates = datasets.value
+    .map(d => d.modified || d.dataUpdatedAt)
+    .filter((d): d is string => !!d)
+  if (!dates.length) return undefined
+  return dates.reduce((a, b) => (a > b ? a : b))
+})
 const datasetsCardConfig = computed(() => {
   const pageConfig = portalConfig.value.applications.page.datasets
   if (!pageConfig || pageConfig.useGlobalCard !== false) {


### PR DESCRIPTION
Show the source data's last-update date on an application's page, next to the visualization's own update date.

- The application page computes the most recent date across its source datasets (`modified`, falling back to `dataUpdatedAt` — matching data-fair's `_modified` fallback) and passes it to `application-metadata`.
- The `updatedAt` label is clarified: "Visualization updated at" vs the new "Data updated at".
- Fixes `dataset-metadata`, which displayed today's date when a dataset had no update date: it now falls back to `updatedAt` and uses a generic "Last update" label in that case.

**Heads-up:** the existing `updatedAt` label text changes ("Updated at" → "Visualization updated at") and `dataset-metadata`'s display logic is modified — it's a shared component, so check the dataset pages too.
