### PR TITLE
fix(api): regenerate element uuids when duplicating a page

### DIFF
--- a/api/src/pages/service.ts
+++ b/api/src/pages/service.ts
@@ -5,6 +5,7 @@ import slug from 'slugify'
 import { assertAccountRole, httpError, type SessionStateAuthenticated } from '@data-fair/lib-express'
 import eventsQueue from '@data-fair/lib-node/events-queue.js'
 import { renderMarkdown } from '@data-fair/portals-shared-markdown'
+import { randomUUID } from 'node:crypto'
 import mongo from '#mongo'
 import config from '#config'
 import { duplicateImage } from '../images/service.ts'
@@ -61,8 +62,9 @@ export const duplicatePageElements = async (
     }
   }
 
-  // Update image references in cloned elements
+  // Update image references in cloned elements, and give each copied element a fresh uuid.
   await traversePageElements(clonedElements, (el) => {
+    if (el.uuid) el.uuid = randomUUID().split('-')[0]
     if (el.type === 'image') {
       updateImageId(el.image)
       updateImageId(el.wideImage)

--- a/tests/features/pages/pages.api.spec.ts
+++ b/tests/features/pages/pages.api.spec.ts
@@ -38,6 +38,7 @@ test.describe('pages management', () => {
     // Add image element to the source page
     const imageElement: ImageElement = {
       type: 'image',
+      uuid: 'srcuuid1',
       image: {
         _id: sourceImage._id,
         mimeType: sourceImage.mimeType,
@@ -64,6 +65,12 @@ test.describe('pages management', () => {
     // Check that the image was duplicated with a new ID
     const duplicatedImageId = duplicatedPage.config.elements[0].image._id
     assert.notEqual(duplicatedImageId, sourceImage._id, 'Image should have a new ID')
+
+    // Copied elements must get a fresh uuid so identity-keyed features (e.g. the per-uuid
+    // shared-filters agent tool) don't collide with the source page during client-side navigation
+    const duplicatedUuid = duplicatedPage.config.elements[0].uuid
+    assert.ok(duplicatedUuid, 'Duplicated element should have a uuid')
+    assert.notEqual(duplicatedUuid, 'srcuuid1', 'Duplicated element should get a new uuid')
 
     // Verify the duplicated image exists in database
     const duplicatedImageData = await user1.get(`/api/images/${duplicatedImageId}/data`)


### PR DESCRIPTION
Regenerate each element's uuid when duplicating a page (`POST /api/pages` with `sourcePageId`), so a copied page no longer shares element uuids with its source.

**Why:** a duplicated page kept the source's element uuids. A `shared-filters` application element registers an agent tool named `describe_filters_<uuid>`; navigating client-side between the source page and its copy made both blocks claim the same tool name, so `registerTool()` threw and the application block's `<d-frame>` visualization failed to render.

**Heads-up:** only affects future duplications — pages already storing duplicate uuids aren't migrated (the `@data-fair/lib-vue-agents` idempotency fix covers those at runtime).
