### PR TITLE
fix(portal): small UI and a11y fixes (nav logo, metrics, contact, reuse card)

### DIFF
--- a/portal/app/components/layout/layout-nav-bar.vue
+++ b/portal/app/components/layout/layout-nav-bar.vue
@@ -22,7 +22,7 @@
           :height="(appBarHeight || 64) - 10"
           :link="navBarConfig.logoLink"
           :logo="logo"
-          class="pl-4"
+          :class="navBarConfig.fluid !== false ? 'pl-4' : undefined"
         />
 
         <nav-tabs-or-drawer

--- a/portal/app/components/page-element/basic/page-element-contact.vue
+++ b/portal/app/components/page-element/basic/page-element-contact.vue
@@ -137,13 +137,12 @@
 
               <v-list-item
                 v-if="portalConfig.contactInformations.phone"
-                ref="phoneItem"
                 :prepend-icon="mdiPhone"
-                :title="portalConfig.contactInformations.phoneLabel || portalConfig.contactInformations.phone"
+                :aria-label="t('phoneAriaLabel', { value: portalConfig.contactInformations.phoneLabel || portalConfig.contactInformations.phone })"
                 :href="`tel:${portalConfig.contactInformations.phone}`"
-                target="_blank"
-                rel="noopener"
-              />
+              >
+                {{ portalConfig.contactInformations.phoneLabel || portalConfig.contactInformations.phone }}
+              </v-list-item>
               <v-list-item
                 v-if="portalConfig.contactInformations.website"
                 ref="websiteItem"
@@ -184,13 +183,6 @@ const { portal, portalConfig, preview } = usePortalStore()
 const url = !preview ? useRequestURL() : null
 
 // v-bind:title.attr causes SSR hydration mismatch with Vuetify 4
-const phoneItem = useTemplateRef('phoneItem')
-watchEffect(() => {
-  const el = phoneItem.value?.$el
-  if (!el) return
-  const title = (portalConfig.value.contactInformations.phoneLabel || portalConfig.value.contactInformations.phone) + ' - ' + t('newWindow')
-  el.setAttribute('title', title)
-})
 const websiteItem = useTemplateRef('websiteItem')
 watchEffect(() => {
   const el = websiteItem.value?.$el
@@ -377,6 +369,7 @@ const sendMessage = useAsyncAction(async () => {
     messageSent: 'Message sent!'
     messageBody: 'Message body:'
     newWindow: 'New window'
+    phoneAriaLabel: 'Phone: {value}'
     send: 'Send'
     socialMedia: 'Find us on social media'
     subject: 'Subject'
@@ -390,6 +383,7 @@ const sendMessage = useAsyncAction(async () => {
     messageSent: 'Message envoyé !'
     messageBody: 'Corps du message :'
     newWindow: 'Nouvelle fenêtre'
+    phoneAriaLabel: 'Téléphone : {value}'
     send: 'Envoyer'
     socialMedia: 'Retrouvez-nous sur les réseaux sociaux'
     subject: 'Sujet'

--- a/portal/app/components/page-element/basic/page-element-metrics.vue
+++ b/portal/app/components/page-element/basic/page-element-metrics.vue
@@ -12,9 +12,9 @@
         :class="[element.mb !== 0 && `mb-${element.mb ?? 4}`, 'text-center']"
         :color="element.color"
       >
-        <v-card-text>
-          <div class="text-headline-medium font-weight-bold">{{ metrics[key] }}</div>
-          <div class="text-headline-small font-weight-light">{{ t('title.' + key) }}</div>
+        <v-card-text class="px-12">
+          <div class="text-headline-small font-weight-bold">{{ metrics[key].toLocaleString(locale) }}</div>
+          <div class="text-title-large font-weight-bold text-uppercase">{{ t('title.' + key) }}</div>
         </v-card-text>
       </v-card>
     </v-col>
@@ -29,7 +29,7 @@ const { element } = defineProps({
 })
 
 const { preview, portal } = usePortalStore()
-const { t } = useI18n()
+const { t, locale } = useI18n()
 
 let metrics: { datasets: number, records: number, applications: number } | ComputedRef<{ datasets: number, records: number, applications: number }>
 if (!preview) {

--- a/portal/app/components/reuse/reuse-card.vue
+++ b/portal/app/components/reuse/reuse-card.vue
@@ -90,17 +90,22 @@
         <v-spacer />
 
         <!-- Publication/update date -->
-        <v-list-item>
-          <p
-            v-if="cardConfig.showAuthor && reuse.config.author"
-            class="text-body-small"
-          >
-            {{ t('publishedBy', { author: reuse.config.author }) }}
-          </p>
-          <p class="text-body-small">
-            {{ t('updatedAt') }} {{ dayjs(reuse.updatedAt).format('L') }}
-          </p>
-        </v-list-item>
+        <v-row
+          no-gutters
+          class="px-4 py-2"
+        >
+          <v-col cols="12">
+            <p
+              v-if="cardConfig.showAuthor && reuse.config.author"
+              class="text-body-small"
+            >
+              {{ t('publishedBy', { author: reuse.config.author }) }}
+            </p>
+            <p class="text-body-small">
+              {{ t('updatedAt') }} {{ dayjs(reuse.updatedAt).format('L') }}
+            </p>
+          </v-col>
+        </v-row>
       </v-col>
     </v-row>
   </v-card>


### PR DESCRIPTION
Quelques petits correctifs visuels et d'accessibilité sur le portail :
- **Logo barre de nav** : plus de double padding gauche quand la barre n'est pas en pleine largeur (le `pl-4` n'est gardé qu'en pleine largeur, où le container n'a pas de padding).
- **Bloc chiffres clés** : rapproché du rendu v1 (titre en gras majuscules, tailles valeur/label calées sur v1, padding horizontal pour aérer les cartes).
- **Lien téléphone du bloc contact** : un `tel:` n'ouvre pas de nouvel onglet → suppression de `target="_blank"` et du `title` « Nouvelle fenêtre » trompeur, ajout d'un `aria-label` explicite, et libellé déplacé dans le slot du `v-list-item` pour qu'il revienne à la ligne au lieu d'être tronqué.
- **Vignette réutilisation** : footer auteur/date aligné sur le layout `v-row no-gutters px-4 py-2` des cartes jeux de données/visualisations.

**Heads-up :** le `px-12` des chiffres clés et la taille de la valeur sont à valider visuellement (notamment sur mobile) contre le portail v1 de référence.
