### PR TITLE
feat(reuses): invite users to propose a reuse on dataset pages

### DIFF
--- a/api/types/portal-config-dataset-page/schema.js
+++ b/api/types/portal-config-dataset-page/schema.js
@@ -213,8 +213,13 @@ export default {
         comp: 'card',
         children: [
           'display',
-          'columns',
-          'useGlobalCard',
+          {
+            children: [
+              'inviteUserReuses',
+              'columns',
+              'useGlobalCard',
+            ]
+          },
           {
             if: 'data?.display === "card" && data?.useGlobalCard === false',
             children: ['card']
@@ -231,6 +236,16 @@ export default {
             { const: 'none', title: 'Aucun' },
             { const: 'card', title: 'Vignette' }
           ]
+        },
+        inviteUserReuses: {
+          type: 'boolean',
+          title: 'Inviter les utilisateurs à proposer une réutilisation',
+          description: 'Rendre la section réutilisations visible en permanence. Un message invite vos utilisateurs à en proposer depuis leur espace personnel.',
+          layout: {
+            if: 'parent.data?.display === "card" && rootData.reuses?.allowUserReuses',
+            comp: 'switch',
+            cols: { md: 4 }
+          },
         },
         columns: {
           type: 'integer',

--- a/portal/app/pages/datasets/[ref]/index.vue
+++ b/portal/app/pages/datasets/[ref]/index.vue
@@ -289,7 +289,7 @@
       </template>
 
       <!-- Reuses section -->
-      <template v-if="portalConfig.datasets.page.reuses?.display && portalConfig.datasets.page.reuses?.display !== 'none' && reuses.length">
+      <template v-if="portalConfig.datasets.page.reuses?.display && portalConfig.datasets.page.reuses?.display !== 'none' && (reuses.length || portalConfig.datasets.page.reuses?.inviteUserReuses)">
         <page-element-title
           :element="{
             type: 'title',
@@ -299,6 +299,14 @@
             line: portalConfig.datasets.page.titleStyle
           }"
         />
+
+        <p v-if="portalConfig.datasets.page.reuses?.inviteUserReuses">
+          <i18n-t keypath="reuseInvitation">
+            <nuxt-link :to="{ path: '/me/reuses', query: { dataset: dataset.id, datasetTitle: dataset.title } }">
+              {{ t('personalSpace') }}
+            </nuxt-link>
+          </i18n-t>
+        </p>
 
         <v-row class="d-flex align-stretch">
           <v-col
@@ -581,6 +589,8 @@ useJsonLd(() => {
     dataset: Dataset
     datasetNotFound: The requested dataset was not found
     datasetError: An error occurred while loading the dataset
+    reuseInvitation: Would you like to share a reuse of this data? Go to your {0}.
+    personalSpace: personal space
     sections:
       application: Linked application | Linked applications
       reuse: Linked reuse | Linked reuse | Linked reuses
@@ -596,6 +606,8 @@ useJsonLd(() => {
     dataset: Jeu de données
     datasetNotFound: Le jeu de données demandé n'a pas été trouvé
     datasetError: Une erreur est survenue lors du chargement du jeu de données
+    reuseInvitation: Vous souhaitez faire connaitre une réutilisation de cette donnée ? Rendez vous dans votre {0}.
+    personalSpace: espace personnel
     sections:
       application: Visualisation associée | Visualisation associée | Visualisations associées
       reuse: Réutilisation associée | Réutilisation associée | Réutilisations associées

--- a/ui/src/pages/embed/reuses.vue
+++ b/ui/src/pages/embed/reuses.vue
@@ -29,7 +29,7 @@
           class="mb-4"
           :loading="createReuse.loading.value"
           :disabled="!!editingReuseId"
-          @click="createReuse.execute()"
+          @click="createReuse.execute(presetConfig)"
         >
           {{ t('createNew') }}
         </v-btn>
@@ -320,16 +320,24 @@ const getSubmissionStatus = (reuse: Reuse) => {
   return 'rejected'
 }
 
-const createReuse = useAsyncAction(async () => {
+const createReuse = useAsyncAction(async (preset?: Partial<Reuse['config']>) => {
   // Create a minimal reuse with empty title to get an ID
   const newReuse = await $fetch<Reuse>('/reuses', {
     method: 'POST',
-    body: { config: { title: '' } }
+    body: { config: { title: '', ...preset } }
   })
   await draftReusesFetch.refresh() // Refresh the list to include the new reuse
   creatingReuseId.value = newReuse._id // Track as newly created so cancel can delete it
   editingReuseId.value = newReuse._id // Start editing the newly created reuse
 })
+
+// When arriving from a dataset page invitation (/me/reuses?dataset=...), pre-fill
+// that dataset into the next reuse the user creates.
+const presetDataset = useStringSearchParam('dataset')
+const presetDatasetTitle = useStringSearchParam('datasetTitle')
+const presetConfig = computed<Partial<Reuse['config']> | undefined>(() => presetDataset.value
+  ? { datasets: [{ id: presetDataset.value, title: presetDatasetTitle.value || presetDataset.value }] }
+  : undefined)
 
 const submitReuse = useAsyncAction(async (reuseId: string) => {
   currentReuseId.value = reuseId


### PR DESCRIPTION
Add an `inviteUserReuses` switch to a dataset page's reuses config. When the portal allows user-submitted reuses and the reuses display is "card", enabling it keeps the reuses section always visible and shows a paragraph inviting visitors to propose a reuse from their personal space, with a link that preselects the current dataset in the creation flow.

**Why:** restore the v1 behaviour where portal visitors are prompted to submit a reuse of a dataset, now as an opt-in per-portal configuration.

**Heads-up:** no automated test — the config-editor gate (visible only when the global toggle is on and display is card) was verified manually in the browser; the portal-side render wasn't exercised end-to-end (no data-fair-dataset e2e precedent in the repo).
