### PR TITLE
feat(page-element): allow a fixed aspect ratio for visualizations

### DIFF
--- a/api/types/page-element-applications/schema.js
+++ b/api/types/page-element-applications/schema.js
@@ -274,36 +274,6 @@ export default {
             }
           }
         },
-        displayMode: {
-          type: 'string',
-          title: "Mode d'affichage",
-          default: 'auto-resize',
-          description: [
-            'Mode de redimensionnement de la visualisation :',
-            "- **Hauteur optimale** - La visualisation peut se redimensionner pour prendre la hauteur dont elle a besoin. Certaines visualisations comme des cartes se comporteront comme le mode **Hauteur optimale avec scroll**. Ce mode évite d'avoir une barre de scroll pour les visualisations qui prennent beaucoup de hauteur.",
-            "- **Hauteur optimale avec scroll** - Hauteur optimisée pour avoir le meilleur ratio largeur / hauteur sur toutes tailles d'écran.",
-            "- **Hauteur fixe (px)** - Vous définissez vous-même la hauteur de la visualisation, peu recommandé pour un affichage sur toute taille d'écran."
-          ].join('\n'),
-          oneOf: [
-            { const: 'auto-resize', title: 'Hauteur optimale' },
-            { const: 'aspect-ratio', title: 'Hauteur optimale avec scroll' },
-            { const: 'fixed-height', title: 'Hauteur fixe (px)' }
-          ]
-        },
-        height: {
-          type: 'integer',
-          title: 'Hauteur (px)',
-          default: 500,
-          minimum: 150,
-          layout: {
-            if: 'parent.data?.displayMode === "fixed-height"',
-            slots: {
-              after: {
-                markdown: "**⚠️ Attention :** une hauteur fixe est déconseillée. Sur les petites résolutions (mobiles, tablettes), l'affichage peut être difficile. Préférez « Hauteur optimale » ou « Hauteur optimale avec scroll » pour un rendu responsive."
-              }
-            }
-          }
-        },
         syncParams: {
           type: 'string',
           title: "Synchronisation des paramètres d'URL",
@@ -319,6 +289,61 @@ export default {
             { const: 'sandboxed', title: 'Synchronisation cloisonnée' },
             { const: 'shared-filters', title: 'Synchronisation avec partage des filtres' }
           ]
+        },
+        displayMode: {
+          type: 'string',
+          title: "Mode d'affichage",
+          default: 'auto-resize',
+          description: [
+            'Mode de redimensionnement de la visualisation :',
+            "- **Hauteur optimale** - La visualisation peut se redimensionner pour prendre la hauteur dont elle a besoin. Certaines visualisations comme des cartes se comporteront comme le mode **Aspect ratio**. Ce mode évite d'avoir une barre de scroll pour les visualisations qui prennent beaucoup de hauteur.",
+            "- **Aspect ratio** - Ratio largeur / hauteur adapté automatiquement à la largeur de l'écran, ou fixé à une valeur constante.",
+            "- **Hauteur fixe (px)** - Vous définissez vous-même la hauteur de la visualisation, peu recommandé pour un affichage sur toute taille d'écran."
+          ].join('\n'),
+          oneOf: [
+            { const: 'auto-resize', title: 'Hauteur optimale' },
+            { const: 'aspect-ratio', title: 'Aspect ratio' },
+            { const: 'fixed-height', title: 'Hauteur fixe (px)' }
+          ]
+        },
+        ratio: {
+          type: 'string',
+          title: 'Ratio (largeur / hauteur)',
+          default: 'auto',
+          layout: {
+            if: 'parent.data?.displayMode === "aspect-ratio"',
+            comp: 'combobox',
+            items: [
+              { value: 'auto', title: 'Auto (Responsive)' },
+              '16/9',
+              '4/3',
+              '1/1',
+              '3/2',
+              '21/9'
+            ]
+          }
+        },
+        maxHeight: {
+          type: 'integer',
+          title: 'Hauteur maximale (px)',
+          minimum: 100,
+          layout: {
+            if: 'parent.data?.displayMode === "aspect-ratio" && !!parent.data?.ratio && parent.data?.ratio !== "auto"'
+          }
+        },
+        height: {
+          type: 'integer',
+          title: 'Hauteur (px)',
+          default: 500,
+          minimum: 150,
+          layout: {
+            if: 'parent.data?.displayMode === "fixed-height"',
+            slots: {
+              after: {
+                markdown: "**⚠️ Attention :** une hauteur fixe est déconseillée. Sur les petites résolutions (mobiles, tablettes), l'affichage peut être difficile. Préférez « Hauteur optimale » ou « Aspect ratio » pour un rendu responsive."
+              }
+            }
+          }
         },
         actionButtons: {
           type: 'object',

--- a/portal/app/components/page-element/applications/page-element-application.vue
+++ b/portal/app/components/page-element/applications/page-element-application.vue
@@ -21,15 +21,24 @@
       :cover="displayMode === 'fixed-height'"
     />
 
-    <d-frame-wrapper
+    <!-- d-frame calcule sa hauteur uniquement à partir de sa propre largeur : il ne peut pas
+         se rétrécir tout seul pour respecter une hauteur maximale. Ce conteneur plafonne donc
+         la largeur (maxHeight × ratio) pour que la hauteur déduite reste sous le maximum,
+         sans recadrer le contenu. -->
+    <div
       v-else
-      :iframe-title="`${t('application')} - ${element.application.title}`"
-      :src="'/data-fair/app/' + element.application.slug + `?d-frame=true&primary=${$vuetify.theme.current.colors.primary}`"
-      :sync-params="syncParams"
-      :aspect-ratio="displayMode !== 'fixed-height' ? '' : undefined"
-      :height="displayMode === 'fixed-height' ? fixedHeight + 'px' : undefined"
-      :resize="displayMode === 'auto-resize' ? undefined : 'no'"
-    />
+      class="mx-auto"
+      :style="pillarboxStyle"
+    >
+      <d-frame-wrapper
+        :iframe-title="`${t('application')} - ${element.application.title}`"
+        :src="'/data-fair/app/' + element.application.slug + `?d-frame=true&primary=${$vuetify.theme.current.colors.primary}`"
+        :sync-params="syncParams"
+        :aspect-ratio="frameAspectRatio"
+        :height="displayMode === 'fixed-height' ? fixedHeight + 'px' : undefined"
+        :resize="displayMode === 'auto-resize' ? undefined : 'no'"
+      />
+    </div>
 
     <application-actions
       v-if="hasActions && application && element.actionButtons?.position === 'bottom'"
@@ -70,6 +79,34 @@ const hasActions = computed(() => (element.actionButtons?.items ?? []).length > 
 
 const displayMode = computed(() => element.displayMode ?? 'auto-resize')
 const fixedHeight = computed(() => element.height ?? 500)
+
+// A fixed ratio can be given as "16/9" or a plain number ("1.78"). "auto" (the default)
+// keeps the current responsive behavior, so it resolves to no fixed ratio.
+const parsedRatio = computed(() => {
+  if (displayMode.value !== 'aspect-ratio' || !element.ratio || element.ratio === 'auto') return undefined
+  const parts = element.ratio.split(/[/:xX]/)
+  if (parts.length === 2) {
+    const a = Number(parts[0]); const b = Number(parts[1])
+    if (a > 0 && b > 0) return a / b
+  }
+  const n = Number(element.ratio)
+  return n > 0 ? n : undefined
+})
+
+// '' lets d-frame pick its own ratio depending on the viewport width.
+const frameAspectRatio = computed(() => {
+  if (displayMode.value === 'fixed-height') return undefined
+  return parsedRatio.value !== undefined ? String(parsedRatio.value) : ''
+})
+
+// d-frame only ever derives its height from its own width. To respect a max height without
+// cropping, the width itself must be capped here so the derived height stays under the max.
+const pillarboxStyle = computed(() => {
+  if (parsedRatio.value !== undefined && element.maxHeight) {
+    return { width: `min(100%, ${element.maxHeight * parsedRatio.value}px)` }
+  }
+  return undefined
+})
 
 const applicationFetcher = preview ? useFetch<Application> : useLocalFetch<Application>
 const applicationFetch = applicationFetcher(() => element.application?.id ? '/data-fair/api/v1/applications/' + element.application.id : '')


### PR DESCRIPTION
- Add a `ratio` field (free text with 16/9, 4/3, 1/1, 3/2, 21/9 suggestions, default `auto`) to keep the current responsive ratio or fix it to a constant value.
- Add an optional `maxHeight` field, shown only when a fixed ratio is set.
- d-frame only computes its height from its own measured width, so it can't cap itself to a max height without cropping; the visualization is now wrapped in a container that caps the width instead (`maxHeight × ratio`), shrinking it horizontally rather than cropping it.
- Renamed the "Hauteur optimale avec scroll" display mode label to "Aspect ratio" (cosmetic only, stored value unchanged).
