### PR TITLE
feat(page-element): add editable option to the dataset table block

### DIFF
--- a/api/types/page-element-datasets/schema.js
+++ b/api/types/page-element-datasets/schema.js
@@ -383,8 +383,7 @@ export default {
         interactions: {
           title: 'Autoriser les interactions',
           description: 'Autorise le tri, la recherche, les filtres,...',
-          type: 'boolean',
-          default: true
+          type: 'boolean'
         },
         editable: {
           title: 'Tableau éditable',

--- a/api/types/page-element-datasets/schema.js
+++ b/api/types/page-element-datasets/schema.js
@@ -324,7 +324,7 @@ export default {
           required: ['id'],
           layout: {
             getItems: {
-              url: '/data-fair/api/v1/datasets?mine=true&raw=true&select=id,title&size=20&sort=updatedAt:-1',
+              url: '/data-fair/api/v1/datasets?mine=true&raw=true&select=id,title,isRest&size=20&sort=updatedAt:-1',
               qSearchParam: 'q',
               itemsResults: 'data.results',
               itemTitle: '`${item.title} (${item.id})`',
@@ -334,7 +334,8 @@ export default {
           properties: {
             id: { type: 'string' },
             title: { type: 'string' },
-            href: { type: 'string' }
+            href: { type: 'string' },
+            isRest: { type: 'boolean' }
           }
         },
         syncParams: {
@@ -384,6 +385,12 @@ export default {
           description: 'Autorise le tri, la recherche, les filtres,...',
           type: 'boolean',
           default: true
+        },
+        editable: {
+          title: 'Tableau éditable',
+          description: "Permet aux utilisateurs autorisés d'éditer les données directement dans le tableau. Les autres visiteurs conservent la vue en lecture seule.",
+          type: 'boolean',
+          layout: { if: 'parent.data?.dataset?.isRest && parent.data?.interactions' }
         },
         mb: { $ref: 'https://github.com/data-fair/portals/page-elements-defs#/$defs/margin-bottom' }
       }

--- a/portal/app/components/page-element/datasets/page-element-dataset-table.vue
+++ b/portal/app/components/page-element/datasets/page-element-dataset-table.vue
@@ -38,7 +38,8 @@ const syncParams = computed(() => {
 
 const url = computed(() => {
   if (!element.dataset) return
-  let ret = `/data-fair/embed/dataset/${element.dataset.id}/table?interaction=${element.interactions}`
+  const route = element.editable ? 'table-edit' : 'table'
+  let ret = `/data-fair/embed/dataset/${element.dataset.id}/${route}?interaction=${element.interactions}`
   if (element.display) ret += `&display=${element.display}`
   if (element.cols && element.cols.length) ret += `&cols=${element.cols.join(',')}`
   return ret

--- a/portal/app/components/page-element/datasets/page-element-dataset-table.vue
+++ b/portal/app/components/page-element/datasets/page-element-dataset-table.vue
@@ -38,7 +38,7 @@ const syncParams = computed(() => {
 
 const url = computed(() => {
   if (!element.dataset) return
-  const route = element.editable ? 'table-edit' : 'table'
+  const route = element.interactions && element.editable ? 'table-edit' : 'table'
   let ret = `/data-fair/embed/dataset/${element.dataset.id}/${route}?interaction=${element.interactions}`
   if (element.display) ret += `&display=${element.display}`
   if (element.cols && element.cols.length) ret += `&cols=${element.cols.join(',')}`


### PR DESCRIPTION
- Adds a "Tableau éditable" (editable table) option to the dataset table page-element block.
- When enabled, the block embeds data-fair's `table-edit` view: authorized users edit rows in place, everyone else keeps the read-only table (read-only degradation is handled natively by data-fair, no error).
- The option is only shown in the page editor for REST (editable) datasets with interactions enabled — `isRest` is now captured when the dataset is selected.

**Why:** let people with write permission edit dataset rows directly from a portal page.

**Heads-up:** relies on data-fair exposing the `/embed/dataset/:id/table-edit` route in the deployed version.
