### PR TITLE
fix(page-element): only show card options when they take effect

### DIFF
--- a/api/types/common-application-card/schema.js
+++ b/api/types/common-application-card/schema.js
@@ -156,7 +156,7 @@ export default {
         useSummary: {
           type: 'boolean',
           title: 'Utiliser le résumé de la visualisation',
-          description: "Affiche le résumé de la visualisation à la place de la capture automatique. Disponible uniquement lorsque l'image est positionnée sous le titre.",
+          description: "Affiche le résumé de la visualisation si disponible, à la place de la capture automatique. Disponible uniquement lorsque l'image est positionnée sous le titre.",
           layout: {
             comp: 'switch',
             cols: { md: 6 },

--- a/api/types/common-application-card/schema.js
+++ b/api/types/common-application-card/schema.js
@@ -28,7 +28,7 @@ export default {
     actionsLocation: {
       type: 'string',
       title: "Position des boutons d'actions sur la carte",
-      layout: { cols: { md: 4 } },
+      layout: { cols: { md: 4 }, if: 'parent.data?.openInFullPage !== true' },
       default: 'bottom',
       oneOf: [
         { const: 'right', title: 'À droite' },
@@ -39,7 +39,7 @@ export default {
     actionsStyle: {
       type: 'string',
       title: "Style des boutons d'actions",
-      layout: { cols: { md: 4 } },
+      layout: { cols: { md: 4 }, if: 'parent.data?.openInFullPage !== true' },
       default: 'full',
       oneOf: [
         { const: 'icon', title: 'Icône seulement' },
@@ -111,6 +111,7 @@ export default {
               'crop',
               'useTopic',
               'useSummary',
+              { markdown: '**Ordre de priorité :**\n1. **Image spécifique** (définie directement sur la visualisation)\n2. **Image de la thématique** (si activé)\n3. **Résumé de la visualisation** (si activé)\n4. **Capture automatique** de la visualisation' }
             ]
           }
         ]
@@ -155,10 +156,11 @@ export default {
         useSummary: {
           type: 'boolean',
           title: 'Utiliser le résumé de la visualisation',
-          description: "Permet d'utiliser le résumé de la visualisation si aucune image n'est définie pour cette dernière et si l'option 'Afficher le résumé' n'est pas activée.",
+          description: "Affiche le résumé de la visualisation à la place de la capture automatique. Disponible uniquement lorsque l'image est positionnée sous le titre.",
           layout: {
             comp: 'switch',
-            cols: { md: 6 }
+            cols: { md: 6 },
+            if: "parent.data?.location === 'center'"
           }
         },
       }

--- a/api/types/common-dataset-card/schema.js
+++ b/api/types/common-dataset-card/schema.js
@@ -176,8 +176,8 @@ export default {
         useSummary: {
           type: 'boolean',
           title: 'Utiliser le résumé du jeu de données',
-          description: "Permet d'utiliser le résumé du jeu de données si aucune image n'est définie pour ce dernier et si l'option 'Afficher le résumé' n'est pas activée.",
-          layout: 'switch'
+          description: "Permet d'utiliser le résumé du jeu de données si aucune image n'est disponible et si l'option 'Afficher le résumé' n'est pas activée. Disponible uniquement lorsque l'image est positionnée sous le titre.",
+          layout: { comp: 'switch', if: "parent.data?.location === 'center'" }
         }
       }
     },

--- a/portal/app/components/application/application-card.vue
+++ b/portal/app/components/application/application-card.vue
@@ -81,7 +81,7 @@
         </div>
 
         <v-card-text
-          v-if="(cardConfig.showSummary || (cardConfig.thumbnail?.show && cardConfig.thumbnail?.useSummary && !thumbnailUrl)) && application.summary?.length"
+          v-if="(cardConfig.showSummary || (cardConfig.thumbnail?.show && cardConfig.thumbnail?.useSummary && cardConfig.thumbnail?.location === 'center' && !thumbnailUrl)) && application.summary?.length"
           class="pb-0"
         >
           {{ application.summary }}
@@ -198,7 +198,7 @@ const thumbnailUrl = computed(() => {
     const topicConfig = portalConfig.value.topics?.find((t) => t.id === application.topics![0]!.id)
     if (topicConfig?.thumbnail) return getPortalImageSrc(topicConfig.thumbnail, false)
   }
-  if (cardConfig.thumbnail?.useSummary && application.summary?.length) return undefined
+  if (cardConfig.thumbnail?.useSummary && cardConfig.thumbnail?.location === 'center' && application.summary?.length) return undefined
   return `${application.href}/capture?updatedAt=${application.updatedAt}`
 })
 

--- a/portal/app/components/dataset/dataset-card.vue
+++ b/portal/app/components/dataset/dataset-card.vue
@@ -81,7 +81,7 @@
         </div>
 
         <v-card-text
-          v-if="(cardConfig.showSummary || (cardConfig.thumbnail?.show && cardConfig.thumbnail?.useSummary && !thumbnailUrl)) && dataset.summary?.length"
+          v-if="(cardConfig.showSummary || (cardConfig.thumbnail?.show && cardConfig.thumbnail?.useSummary && cardConfig.thumbnail?.location === 'center' && !thumbnailUrl)) && dataset.summary?.length"
           class="pb-0"
         >
           {{ dataset.summary }}


### PR DESCRIPTION
Sur les vignettes de visualisation et de jeu de données, n'affiche les options de configuration que quand elles ont un effet :
- Masque « Position » et « Style » des boutons d'actions quand la carte s'ouvre en plein écran (les boutons « Aperçu » / « Plein écran » sont alors masqués, le réglage n'avait plus d'effet).
- N'affiche « Utiliser le résumé » — et n'applique le repli résumé au rendu — que si l'image est positionnée « Sous le titre » (visu + jeu de données).
- Corrige la description de « Utiliser le résumé » d'une visu (il remplace la capture automatique) et ajoute l'ordre de priorité de l'image.

**Pourquoi :** les boutons d'actions disparaissaient sans explication et le réglage de position semblait inutile ; et « utiliser le résumé » n'avait de sens visuel que sous le titre (sinon colonne image vide ou résumé mal placé).

**Heads-up :** changement de rendu pour d'éventuels portails existants ayant « utiliser le résumé » activé avec une image « À gauche » / « En haut » : ils afficheront désormais la capture (visu) plutôt que le résumé. Cas rare (l'image est « Sous le titre » par défaut).
