### PR TITLE
feat(portal-config): dark theme logo variant, fix portal creation

### DIFF
--- a/api/src/portals/router.ts
+++ b/api/src/portals/router.ts
@@ -49,10 +49,9 @@ router.post('', async (req, res, next) => {
     menu: {
       children: []
     },
-    allowRobots: !body.config, // By default, allow robots if not a staging portal
     authentication: 'optional' as const,
     theme: fillTheme(defaultTheme, defaultTheme),
-    header: {},
+    header: { show: true, showTitle: true },
     navBar: {},
     breadcrumb: {},
     footer: {

--- a/api/src/portals/service.ts
+++ b/api/src/portals/service.ts
@@ -456,6 +456,7 @@ export const duplicatePortalConfig = async (
   rewrite(duplicatedConfig.errorImages?.forbidden)
   rewrite(duplicatedConfig.errorImages?.fallback)
   rewrite(duplicatedConfig.footer.logoPrimary)
+  rewrite(duplicatedConfig.footer.logoPrimaryDark)
   rewrite(duplicatedConfig.footer.backgroundImage)
   rewrite(duplicatedConfig.header.logoPrimary)
   rewrite(duplicatedConfig.header.logoPrimaryMobile)
@@ -488,6 +489,7 @@ const getPortalConfigImageRefs = (portalConfig: PortalConfig) => {
     portalConfig.errorImages?.forbidden,
     portalConfig.errorImages?.fallback,
     portalConfig.footer.logoPrimary,
+    portalConfig.footer.logoPrimaryDark,
     portalConfig.footer.backgroundImage,
     portalConfig.header.logoPrimary,
     portalConfig.header.logoPrimaryMobile,

--- a/api/types/portal-config-footer/schema.js
+++ b/api/types/portal-config-footer/schema.js
@@ -21,9 +21,10 @@ export default {
         comp: 'card',
         title: 'Logo',
         children: [
-          [{ key: 'logoPrimaryType', cols: { md: 6 } }, { key: 'logoPrimary', cols: { md: 6 } }],
-          'logoPrimaryDark',
-          'logoPrimaryLink',
+          { key: 'logoPrimaryType', cols: { md: 6 } },
+          { key: 'logoPrimary', cols: { md: 6 } },
+          { key: 'logoPrimaryDark', cols: { md: 6 } },
+          { key: 'logoPrimaryLink', cols: { md: 6 } },
           { key: 'logoPosition', cols: { md: 6 } },
           { key: 'logoAlignment', cols: { md: 6 } }
         ]

--- a/api/types/portal-config-footer/schema.js
+++ b/api/types/portal-config-footer/schema.js
@@ -22,6 +22,7 @@ export default {
         title: 'Logo',
         children: [
           [{ key: 'logoPrimaryType', cols: { md: 6 } }, { key: 'logoPrimary', cols: { md: 6 } }],
+          'logoPrimaryDark',
           'logoPrimaryLink',
           { key: 'logoPosition', cols: { md: 6 } },
           { key: 'logoAlignment', cols: { md: 6 } }
@@ -110,6 +111,34 @@ export default {
           component: {
             name: 'image-upload',
             props: { width: 1280, label: 'Logo principal' }
+          }
+        },
+      },
+      properties: {
+        _id: {
+          type: 'string'
+        },
+        name: {
+          type: 'string'
+        },
+        mimeType: {
+          type: 'string'
+        },
+        mobileAlt: {
+          type: 'boolean'
+        }
+      }
+    },
+    logoPrimaryDark: {
+      type: 'object',
+      title: 'Logo principal - variante pour thème sombre',
+      required: ['_id', 'name', 'mimeType'],
+      layout: {
+        if: 'parent.data?.logoPrimaryType === "local"',
+        slots: {
+          component: {
+            name: 'image-upload',
+            props: { width: 1280, label: 'Logo principal - variante pour thème sombre' }
           }
         },
       },

--- a/api/types/portal-config/schema.js
+++ b/api/types/portal-config/schema.js
@@ -311,13 +311,13 @@ export default {
     },
     logoDark: {
       type: 'object',
-      title: 'Logo - variante pour fond sombre',
+      title: 'Logo - variante pour thème sombre',
       required: ['_id', 'name', 'mimeType'],
       layout: {
         slots: {
           component: {
             name: 'image-upload',
-            props: { width: 1280, label: 'Logo - variante pour fond sombre' }
+            props: { width: 1280, label: 'Logo - variante pour thème sombre' }
           }
         },
         cols: { md: 6 }

--- a/portal/app/components/layout/layout-footer.vue
+++ b/portal/app/components/layout/layout-footer.vue
@@ -287,17 +287,18 @@ const { t, locale } = useI18n()
 const { portal, portalConfig } = usePortalStore()
 const { resolveLink, resolveLinkTitle } = useNavigationStore()
 const getPortalImageSrc = usePortalImageSrc()
+const themedLogo = useThemedLogo()
 
 const logo = computed(() => {
-  const { footer, header, logo: defaultLogo } = portalConfig.value
+  const { footer, header, logo: defaultLogo, logoDark } = portalConfig.value
 
   switch (footer.logoPrimaryType) {
-    case 'default': return defaultLogo
+    case 'default': return themedLogo(defaultLogo, logoDark)
     case 'header':
       if (header.logoPrimaryType === 'local' && header.logoPrimary) return header.logoPrimary
-      if (header.logoPrimaryType === 'default') return defaultLogo
+      if (header.logoPrimaryType === 'default') return themedLogo(defaultLogo, logoDark)
       return undefined
-    case 'local': return footer.logoPrimary
+    case 'local': return themedLogo(footer.logoPrimary, footer.logoPrimaryDark)
     default: return undefined
   }
 })

--- a/portal/app/components/layout/layout-full-app-bar.vue
+++ b/portal/app/components/layout/layout-full-app-bar.vue
@@ -6,9 +6,9 @@
   >
     <!-- Logo -->
     <layout-header-logo
-      v-if="portalConfig.logo"
+      v-if="logo"
       :height="(appBarHeight || 64) - 10"
-      :logo="portalConfig.logo"
+      :logo="logo"
     />
 
     <!-- Breadcrumbs -->
@@ -25,8 +25,11 @@
 import { useElementSize } from '@vueuse/core'
 
 const { portalConfig } = usePortalStore()
+const themedLogo = useThemedLogo()
 
 const appBarRef = ref()
 const { height: appBarHeight } = useElementSize(appBarRef)
+
+const logo = computed(() => themedLogo(portalConfig.value.logo, portalConfig.value.logoDark))
 
 </script>

--- a/portal/app/components/layout/layout-header.vue
+++ b/portal/app/components/layout/layout-header.vue
@@ -42,6 +42,7 @@ const { headerConfig } = defineProps<{ headerConfig: Header }>()
 
 const { portalConfig } = usePortalStore()
 const display = useDisplay()
+const themedLogo = useThemedLogo()
 
 /**
  * Logo selection rules:
@@ -58,7 +59,7 @@ const logo = computed(() => {
   const primaryLogo = headerConfig.logoPrimaryType === 'local'
     ? headerConfig.logoPrimary || null
     : headerConfig.logoPrimaryType === 'default'
-      ? portalConfig.value.logo || null
+      ? themedLogo(portalConfig.value.logo, portalConfig.value.logoDark) || null
       : null
 
   // Centering hides the title, so treat it as "title hidden" for the mobile fallback.

--- a/portal/app/components/layout/layout-nav-bar.vue
+++ b/portal/app/components/layout/layout-nav-bar.vue
@@ -77,6 +77,7 @@ const { navBarConfig } = defineProps<{
 const { portalConfig, preview } = usePortalStore()
 const display = useDisplay()
 const { t } = useI18n()
+const themedLogo = useThemedLogo()
 
 const appBarRef = ref()
 const { height: appBarHeight } = useElementSize(appBarRef)
@@ -88,7 +89,7 @@ const logo = computed(() => {
   } else if (navBarConfig.logoType === 'local' && navBarConfig.logo) {
     return navBarConfig.logo
   } else if (navBarConfig.logoType === 'default' && portalConfig.value.logo) {
-    return portalConfig.value.logo
+    return themedLogo(portalConfig.value.logo, portalConfig.value.logoDark)
   }
   return null
 })

--- a/portal/app/composables/use-themed-logo.ts
+++ b/portal/app/composables/use-themed-logo.ts
@@ -1,0 +1,13 @@
+import { useTheme } from 'vuetify'
+import type { ImageRef } from '#api/types/image-ref/index.ts'
+
+/**
+ * The logo variant follows the applied theme, not the lightness of the
+ * background behind it: it is up to the portal admin to provide the logo that
+ * suits each theme. theme.current.value.dark covers both 'dark' and 'hc-dark'.
+ */
+export const useThemedLogo = () => {
+  const theme = useTheme()
+  return (logo?: ImageRef, logoDark?: ImageRef) =>
+    theme.current.value.dark && logoDark ? logoDark : logo
+}

--- a/tests/e2e-warmup.ts
+++ b/tests/e2e-warmup.ts
@@ -34,7 +34,8 @@ setup('Warmup heavy dev routes', async ({ page, context }) => {
     waitUntil: 'domcontentloaded',
     timeout: 60_000
   })
-  await expect(page.getByText('Warmup')).toBeVisible({ timeout: 60_000 })
+  // exact: the portal title "Warmup Portal" is rendered in the header too
+  await expect(page.getByText('Warmup', { exact: true })).toBeVisible({ timeout: 60_000 })
   stamp('portal home rendered')
 
   // 2) Warm up the manager SPA + auth flow by logging in with redirect to the

--- a/ui/src/composables/use-themed-logo.ts
+++ b/ui/src/composables/use-themed-logo.ts
@@ -1,0 +1,12 @@
+import { useTheme } from 'vuetify'
+import type { ImageRef } from '#api/types/image-ref/index.ts'
+
+// mirrors portal/app/composables/use-themed-logo.ts: shared layout components
+// resolve their auto-imports here, and the ui build stage of the Dockerfile does
+// not copy portal/app/composables. In the editor previews the theme is always
+// light, so this always returns the base logo.
+export const useThemedLogo = () => {
+  const theme = useTheme()
+  return (logo?: ImageRef, logoDark?: ImageRef) =>
+    theme.current.value.dark && logoDark ? logoDark : logo
+}

--- a/ui/src/pages/portals/new.vue
+++ b/ui/src/pages/portals/new.vue
@@ -707,8 +707,8 @@ const createPortal = useAsyncAction(
       method: 'POST',
       body: {
         owner,
-        sourcePortalId: selectedPortal.value !== 'blank' ? selectedPortal.value : undefined, // Source page ID to duplicate (optional)
-        config: { title: portalTitle, menu: selectedPortal.value !== 'blank' ? undefined : menu } // Init menu only if not duplicating from another portal
+        sourcePortalId: selectedPortal.value,
+        config: { title: portalTitle, menu: selectedPortal.value ? undefined : menu } // Init menu only if not duplicating, a source portal brings its own
       }
     })
 


### PR DESCRIPTION
Make the portal logo follow the dark theme, and fix portal creation so a new portal is usable without opening the editor first.

- `config.logoDark` was declared in the schema, accepted, stored and duplicated by the API, but never read by any rendering component. It is now served on its four render sites (header, nav bar, full app bar, footer) whenever the applied theme is dark (`dark` or `hc-dark`), falling back to the base logo when unset.
- Added `footer.logoPrimaryDark` for the footer's own local logo, the one case `logoDark` cannot cover.
- Portal creation never sent the navigation menu: the wizard tested a `'blank'` sentinel that only exists for pages, so the condition was always true and every new portal got an empty navigation bar — not even the home link it always adds.
- Newly created portals had no header: `header` was initialized to `{}` while the schema defaults `show` and `showTitle` to true, so the app bar collapsed to a height of 0 and the portal title was never rendered.
- Dropped `allowRobots: !body.config`, dead code that was always false since `config` is required in the request body.

**Why:** a footer using `surface-inverse` flips from dark to light with the theme while its logo stays a single file, so a white-on-dark logo vanishes; and creating a portal left it non-functional until its config was first saved from the editor.

**Heads-up:** portals that already set `logoDark` will now display it in dark theme instead of ignoring it. The variant follows the applied theme, not the lightness of the background behind the logo — one `logoDark` serves all four sites, so the admin picks the logo that suits each theme.
