### PR TITLE
perf: speed up the page edit UI

### DIFF
--- a/portal/app/components/page-element/layout/page-element-responsive-grid.vue
+++ b/portal/app/components/page-element/layout/page-element-responsive-grid.vue
@@ -37,6 +37,9 @@
 <script setup lang="ts">
 import type { PageElement, ResponsiveGridElement } from '#api/types/page-elements/index.ts'
 
+// inheritAttrs:false silences the extraneous-attrs warning: the preview root is a
+// fragment (slot) and the `context` attr passed by page-element cannot be inherited
+defineOptions({ inheritAttrs: false })
 const { element } = defineProps<{ element: ResponsiveGridElement }>()
 const { preview } = usePortalStore()
 

--- a/ui/src/components/page/page-preview-element.vue
+++ b/ui/src/components/page/page-preview-element.vue
@@ -35,8 +35,6 @@ const renderedElement = computed(() => {
 const previewDefaults = {
   // counteract the density defined by vjsf in edit mode
   global: { density: 'default' },
-  // applies to the nested page-edit-elements editors of container elements,
-  // merged here to avoid a second v-defaults-provider per preview
   'VjsfList-VCard': {
     border: false
   }

--- a/ui/src/components/page/page-preview-element.vue
+++ b/ui/src/components/page/page-preview-element.vue
@@ -6,14 +6,12 @@
       :context="context"
     >
       <template #page-elements="{ elements, onUpdate, addItemMessage }">
-        <v-defaults-provider :defaults="vjsfDefaults">
-          <page-edit-elements
-            :model-value="elements"
-            :add-item-message="addItemMessage"
-            :pages="pages"
-            @update:model-value="(newElements: PageElement[] | undefined) => element = onUpdate(newElements ?? [])"
-          />
-        </v-defaults-provider>
+        <page-edit-elements
+          :model-value="elements"
+          :add-item-message="addItemMessage"
+          :pages="pages"
+          @update:model-value="(newElements: PageElement[] | undefined) => element = onUpdate(newElements ?? [])"
+        />
       </template>
     </page-element>
   </v-defaults-provider>
@@ -36,10 +34,9 @@ const renderedElement = computed(() => {
 
 const previewDefaults = {
   // counteract the density defined by vjsf in edit mode
-  global: { density: 'default' }
-}
-
-const vjsfDefaults = {
+  global: { density: 'default' },
+  // applies to the nested page-edit-elements editors of container elements,
+  // merged here to avoid a second v-defaults-provider per preview
   'VjsfList-VCard': {
     border: false
   }

--- a/ui/src/pages/pages/[pageId]/edit-config.vue
+++ b/ui/src/pages/pages/[pageId]/edit-config.vue
@@ -55,6 +55,7 @@
 import type { Options as VjsfOptions } from '@koumoul/vjsf'
 import type { Page, Group, PageConfig } from '#api/types/page/index.ts'
 
+import equal from 'fast-deep-equal'
 import { renderMarkdown } from '@data-fair/portals-shared-markdown'
 import NavigationRight from '@data-fair/lib-vuetify/navigation-right.vue'
 import { DfAgentChatAction } from '@data-fair/lib-vuetify-agents'
@@ -68,7 +69,12 @@ const { pageFetch, patchPage } = usePageStore()
 
 const editConfig = ref<PageConfig>()
 watch(pageFetch.data, () => {
-  if (pageFetch.data.value) editConfig.value = pageFetch.data.value.draftConfig
+  if (!pageFetch.data.value) return
+  // a refresh after validating/canceling the draft can return a draftConfig identical
+  // to the one being edited, do not reassign in that case as it would re-hydrate the
+  // whole form and re-mount every element preview
+  if (equal(toRaw(editConfig.value), pageFetch.data.value.draftConfig)) return
+  editConfig.value = pageFetch.data.value.draftConfig
 }, { immediate: true })
 provide('page-config', editConfig)
 

--- a/ui/src/pages/pages/[pageId]/edit-config.vue
+++ b/ui/src/pages/pages/[pageId]/edit-config.vue
@@ -70,9 +70,6 @@ const { pageFetch, patchPage } = usePageStore()
 const editConfig = ref<PageConfig>()
 watch(pageFetch.data, () => {
   if (!pageFetch.data.value) return
-  // a refresh after validating/canceling the draft can return a draftConfig identical
-  // to the one being edited, do not reassign in that case as it would re-hydrate the
-  // whole form and re-mount every element preview
   if (equal(toRaw(editConfig.value), pageFetch.data.value.draftConfig)) return
   editConfig.value = pageFetch.data.value.draftConfig
 }, { immediate: true })

--- a/ui/src/pages/portals/[id]/index.vue
+++ b/ui/src/pages/portals/[id]/index.vue
@@ -213,18 +213,32 @@ watch(editConfig, (newConfig) => {
 // When switching from assisted to manual mode, expand assisted colors into the full palette
 // When switching from manual to assisted mode, carry over primary/secondary/accent into assistedModeColors
 watch(() => editConfig.value?.theme?.assistedMode, (newVal, oldVal) => {
+  // reassign editConfig instead of mutating it in place, the vjsf form only
+  // observes changes of identity of its model
   if (oldVal === true && newVal === false && editConfig.value?.theme) {
     const filled = fillTheme({ ...editConfig.value.theme, assistedMode: true }, defaultTheme)
-    editConfig.value.theme.colors = filled.colors
-    editConfig.value.theme.darkColors = filled.darkColors
-    editConfig.value.theme.hcColors = filled.hcColors
-    editConfig.value.theme.hcDarkColors = filled.hcDarkColors
+    editConfig.value = {
+      ...editConfig.value,
+      theme: {
+        ...editConfig.value.theme,
+        colors: filled.colors,
+        darkColors: filled.darkColors,
+        hcColors: filled.hcColors,
+        hcDarkColors: filled.hcDarkColors
+      }
+    }
   }
   if (oldVal === false && newVal === true && editConfig.value?.theme) {
-    editConfig.value.theme.assistedModeColors = {
-      primary: editConfig.value.theme.colors?.primary ?? defaultTheme.colors.primary,
-      secondary: editConfig.value.theme.colors?.secondary ?? defaultTheme.colors.secondary,
-      accent: editConfig.value.theme.colors?.accent ?? defaultTheme.colors.accent
+    editConfig.value = {
+      ...editConfig.value,
+      theme: {
+        ...editConfig.value.theme,
+        assistedModeColors: {
+          primary: editConfig.value.theme.colors?.primary ?? defaultTheme.colors.primary,
+          secondary: editConfig.value.theme.colors?.secondary ?? defaultTheme.colors.secondary,
+          accent: editConfig.value.theme.colors?.accent ?? defaultTheme.colors.accent
+        }
+      }
     }
   }
 })

--- a/ui/src/pages/portals/[id]/index.vue
+++ b/ui/src/pages/portals/[id]/index.vue
@@ -213,8 +213,6 @@ watch(editConfig, (newConfig) => {
 // When switching from assisted to manual mode, expand assisted colors into the full palette
 // When switching from manual to assisted mode, carry over primary/secondary/accent into assistedModeColors
 watch(() => editConfig.value?.theme?.assistedMode, (newVal, oldVal) => {
-  // reassign editConfig instead of mutating it in place, the vjsf form only
-  // observes changes of identity of its model
   if (oldVal === true && newVal === false && editConfig.value?.theme) {
     const filled = fillTheme({ ...editConfig.value.theme, assistedMode: true }, defaultTheme)
     editConfig.value = {


### PR DESCRIPTION
Three fixes for the sluggish page edit UI (measured on a real 68-element home page config):

- do not reassign `editConfig` when the refetched `draftConfig` is deep-equal: validating or canceling the draft re-hydrated the whole vjsf form and re-mounted every element preview (~4s of blocked main thread → ~0)
- silence the extraneous-attrs warning on the responsive grid preview (fragment root): vite dev serializes and forwards every console argument, including this warning's huge component trace, on every re-render (~3s per interaction in dev)
- merge the two nested `v-defaults-provider`s of element previews into one

Also fixes the theme color mode switch to reassign `editConfig` instead of mutating it in place: the mutation was only picked up thanks to a wasteful full vjsf rebuild on every interaction, which the upcoming vjsf release removes (koumoul-dev/vuetify-jsonschema-form#588). Covered by the existing color-preservation e2e tests; full e2e suite green (82 passed).

**Heads-up:** independent from the vjsf/json-layout/lib releases — works with the currently published versions; the big form-interaction gains land with the vjsf bump.
