### PR TITLE
fix(portal): accessibility quick wins from the RGAA audit

### DIFF
--- a/portal/app/components/catalog-filters.vue
+++ b/portal/app/components/catalog-filters.vue
@@ -9,6 +9,7 @@
       v-model="search"
       :append-inner-icon="mdiMagnify"
       :label="t('search')"
+      :aria-label="t(`searchByType.${catalogType}`)"
       :density="config.filters?.density ?? portalConfig.defaults?.density"
       :rounded="config.filters?.rounded ?? portalConfig.defaults?.rounded"
       variant="outlined"
@@ -425,6 +426,12 @@ const sortItems = computed(() => {
       noOwners: No owners available
       noChoices: No choices available # When a label is overridden
     search: Search
+    searchByType:
+      datasets: Search for a dataset
+      applications: Search for a visualization
+      reuses: Search for a reuse
+      events: Search for an event
+      news: Search for a news item
     sort:
       createdAt: Creation date
       modified: Update date
@@ -450,6 +457,12 @@ const sortItems = computed(() => {
       noOwners: Aucun propriétaire disponible
       noChoices: Aucun choix disponible # When owner label is overridden
     search: Rechercher
+    searchByType:
+      datasets: Rechercher un jeu de données
+      applications: Rechercher une visualisation
+      reuses: Rechercher une réutilisation
+      events: Rechercher un événement
+      news: Rechercher une actualité
     sort:
       createdAt: Date de création
       modified: Date de mise à jour

--- a/portal/app/components/catalog-layout.vue
+++ b/portal/app/components/catalog-layout.vue
@@ -18,7 +18,7 @@
     <v-col>
       <!-- Action announcements for screen readers (sort, pagination) -->
       <div
-        class="visually-hidden"
+        class="d-sr-only"
         role="status"
         aria-live="polite"
         aria-atomic="true"
@@ -246,17 +246,3 @@ watch(() => props.currentPage, (newPage) => {
     sortAnnouncement: 'Tri par {sort}, {order}'
     pageAnnouncement: 'Page {current} sur {total}'
 </i18n>
-
-<style scoped>
-.visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-</style>

--- a/portal/app/components/nav/nav-drawer.vue
+++ b/portal/app/components/nav/nav-drawer.vue
@@ -7,6 +7,7 @@
     temporary
   >
     <v-list
+      role="presentation"
       color="primary"
       nav
     >

--- a/portal/app/components/page-element/basic/page-element-contact.vue
+++ b/portal/app/components/page-element/basic/page-element-contact.vue
@@ -18,6 +18,8 @@
               v-model="message.from"
               :label="t('email')"
               :rules="[rules.required(), rules.email()]"
+              type="email"
+              autocomplete="email"
             />
 
             <!-- Additional fields -->

--- a/portal/app/components/page-error.vue
+++ b/portal/app/components/page-error.vue
@@ -28,9 +28,12 @@
         />
         <error-server v-else style="max-height: 300px" />
       </template>
-      <div class="text-headline-small my-4">
+      <component
+        :is="headingTag"
+        class="text-headline-small my-4"
+      >
         {{ title }}
-      </div>
+      </component>
       <nav-link
         :link="{
           ...(link ? link : { type: 'standard', subtype: 'home' }),
@@ -66,6 +69,7 @@ const defaultTitles: Record<number, string> = {
 }
 
 const title = computed(() => props.title || defaultTitles[props.statusCode] || t('error'))
+const headingTag = computed(() => (portalConfig.value.header?.show && portalConfig.value.header?.showTitle) ? 'h2' : 'h1')
 
 const getErrorImageSrc = (type: 'notFound' | 'forbidden' | 'fallback') => {
   const image = portalConfig.value.errorImages?.[type]

--- a/portal/app/error.vue
+++ b/portal/app/error.vue
@@ -1,9 +1,9 @@
 <template>
-  <v-container>
-    <v-alert
-      v-if="error.statusCode !== 401"
-      type="error"
-    >
+  <v-container v-if="error.status !== 401">
+    <h1 class="text-headline-medium my-4">
+      {{ error.status }} - {{ documentTitle }}
+    </h1>
+    <v-alert type="error">
       {{ error.message }}
     </v-alert>
   </v-container>
@@ -13,11 +13,31 @@
 import type { NuxtError } from '#app'
 
 const { error } = defineProps<{ error: NuxtError }>()
+const { t } = useI18n()
+
+// Distinct document title per error type (RGAA 8.5)
+const documentTitle = computed(() => {
+  if (error.status === 404) return t('notFound')
+  if (error.status === 403) return t('forbidden')
+  return t('error')
+})
+useHead({ title: () => documentTitle.value })
 
 console.log('Error: ', error)
-if (error.statusCode === 401) {
+if (error.status === 401) {
   const session = useSession()
   session.login()
 }
 
 </script>
+
+<i18n lang="yaml">
+  en:
+    notFound: Page not found
+    forbidden: Access forbidden
+    error: An error occurred
+  fr:
+    notFound: Page introuvable
+    forbidden: Accès interdit
+    error: Une erreur s'est produite
+</i18n>

--- a/portal/app/error.vue
+++ b/portal/app/error.vue
@@ -1,19 +1,24 @@
 <template>
-  <v-container v-if="error.status !== 401">
-    <h1 class="text-headline-medium my-4">
-      {{ error.status }} - {{ documentTitle }}
-    </h1>
-    <v-alert type="error">
-      {{ error.message }}
-    </v-alert>
-  </v-container>
+  <!-- This page must stay minimal and self-sufficient: it can render while the portal
+       config, theme or links are broken, so no header/footer/layout here. The static
+       main landmark and html lang are the only structure it can safely promise. -->
+  <main v-if="error.status !== 401">
+    <v-container>
+      <h1 class="text-headline-medium my-4">
+        {{ error.status }} - {{ documentTitle }}
+      </h1>
+      <v-alert type="error">
+        {{ error.message }}
+      </v-alert>
+    </v-container>
+  </main>
 </template>
 
 <script setup lang="ts">
 import type { NuxtError } from '#app'
 
 const { error } = defineProps<{ error: NuxtError }>()
-const { t } = useI18n()
+const { t, locale } = useI18n()
 
 // Distinct document title per error type (RGAA 8.5)
 const documentTitle = computed(() => {
@@ -21,7 +26,7 @@ const documentTitle = computed(() => {
   if (error.status === 403) return t('forbidden')
   return t('error')
 })
-useHead({ title: () => documentTitle.value })
+useHead({ title: () => documentTitle.value, htmlAttrs: { lang: () => locale.value } })
 
 console.log('Error: ', error)
 if (error.status === 401) {

--- a/portal/app/layouts/full.vue
+++ b/portal/app/layouts/full.vue
@@ -1,12 +1,26 @@
 <template>
+  <LayoutSkipLinks :targets="skipLinkTargets" />
   <LayoutFullAppBar />
   <v-main>
-    <v-container fluid class="pa-0 h-100">
+    <v-container
+      id="contenu"
+      fluid
+      class="pa-0 h-100"
+      tabindex="-1"
+    >
       <slot />
     </v-container>
   </v-main>
   <LayoutScrollToTop />
 </template>
+
+<script setup lang="ts">
+
+const skipLinkTargets = [
+  { id: 'contenu', labelKey: 'content' }
+]
+
+</script>
 
 <style>
 /* https://stackoverflow.com/questions/56973002/vuetify-adds-scrollbar-when-its-not-needed */

--- a/portal/app/pages/applications/[ref]/full.vue
+++ b/portal/app/pages/applications/[ref]/full.vue
@@ -1,4 +1,8 @@
 <template>
+  <h1 class="d-sr-only">
+    {{ `${applicationFetch.data.value?.title || t('application')} - ${t('fullscreen')}` }}
+  </h1>
+
   <d-frame-wrapper
     :iframe-title="`${t('application')} - ${applicationFetch.data.value?.title} - ${t('fullscreen')}`"
     :src="`/data-fair/app/${$route.params.ref}?d-frame=true&primary=${$vuetify.theme.current.colors.primary}`"

--- a/portal/app/pages/datasets/[ref]/map.vue
+++ b/portal/app/pages/datasets/[ref]/map.vue
@@ -1,4 +1,8 @@
 <template>
+  <h1 class="d-sr-only">
+    {{ `${datasetFetch.data.value?.title || t('dataset')} - ${t('map')}` }}
+  </h1>
+
   <d-frame-wrapper
     :iframe-title="`${t('dataset')} - ${datasetFetch.data.value?.title} - ${t('map')}`"
     :src="`/data-fair/embed/dataset/${$route.params.ref}/map`"
@@ -82,3 +86,4 @@ onMounted(() => window.parent.postMessage(['df-child', 'reinit-height'], '*'))
     dataset: Jeu de données
     map: Carte
 </i18n>
+

--- a/portal/app/pages/datasets/[ref]/table.vue
+++ b/portal/app/pages/datasets/[ref]/table.vue
@@ -1,4 +1,8 @@
 <template>
+  <h1 class="d-sr-only">
+    {{ `${datasetFetch.data.value?.title || t('dataset')} - ${t('table')}` }}
+  </h1>
+
   <d-frame-wrapper
     :iframe-title="`${t('dataset')} - ${datasetFetch.data.value?.title} - ${t('table')}`"
     :src="`/data-fair/embed/dataset/${$route.params.ref}/table`"
@@ -84,3 +88,4 @@ onMounted(() => window.parent.postMessage(['df-child', 'reinit-height'], '*'))
     dataset: Jeu de données
     table: Tableau
 </i18n>
+


### PR DESCRIPTION
Accessibility fixes on the portal front-end, from the internal RGAA 4.1 audit of the Data Corsica portal, re-checked against the EDF Open Data grid.

- catalog search fields: explicit `aria-label` per catalog type (11.2), visible label unchanged
- contact form: `type="email"` + `autocomplete="email"` (11.13)
- bare error page (`error.vue`, route 404s rendered outside the app shell): `<h1>`, distinct `<title>` per status, static `<main>` landmark and `html lang` (8.3/8.5/9.1/9.2/12.6). It stays deliberately minimal so it renders even when the portal config, theme or links are broken — no header/footer by design
- `page-error` component (content 404s, rendered inside the layout): conditional h1/h2 depending on whether the header already shows the portal title (9.1)
- full-screen layout: skip link to the content (12.7)
- full-screen dataset table, map and application views: visually hidden `<h1>`. The audited document is the portal page shell — the data-fair view is only an iframe — so the heading hierarchy has to start in the shell (9.1)
- mobile nav drawer: `role="presentation"` on the `v-list` to drop its broken ARIA list semantics (9.3)
- `catalog-layout` now uses Vuetify's `d-sr-only` utility instead of a local `visually-hidden` class

**Why:** accessibility quick wins from the RGAA audit on the portal front-end.

**Heads-up:**
- `error.vue` now reads `error.status` (was `statusCode`), which gates both the whole render and the 401 → login redirect. Worth exercising a real 401.
- `role="presentation"` is *ignored* by the browser here: ARIA conflict resolution drops it on focusable elements, and Vuetify hardcodes `tabindex="0"` on `v-list` (forcing `-1` changes nothing). The element falls back to the div's implicit `generic` role — the outcome we want, and deterministic. A valid ARIA list is not reachable with this component: `VListItem` renders links as `<a role="link">`, and one element cannot be both `listitem` and `link`. Automated tooling may report `presentation-role-conflict` (axe best-practice, not a violation).
- No e2e coverage for the new guarantees (no list role in the drawer, skip link, full-screen h1s, `lang` on the bare error page), though the suite already asserts roles elsewhere (`tests/features/portal-rendering/page-toc.e2e.spec.ts`).
