### PR TITLE
feat(portal): option to keep the portal layout on the catalog API doc page

### DIFF
--- a/api/types/portal-config/schema.js
+++ b/api/types/portal-config/schema.js
@@ -95,6 +95,11 @@ export default {
               'navLinksConfig',
               { name: 'nav-link-preview' }
             ]
+          },
+          {
+            title: "Documentation d'API",
+            comp: 'card',
+            children: ['catalogApiDocFullLayout']
           }
         ]
       },
@@ -225,6 +230,12 @@ export default {
       type: 'boolean',
       title: 'Rendre le portail visible sur les moteurs de recherche',
       description: "Permettre à Google et aux autres moteurs de recherche d'indexer ce portail pour qu'il soit visible dans les résultats de recherche.",
+      layout: 'switch'
+    },
+    catalogApiDocFullLayout: {
+      type: 'boolean',
+      title: "Conserver l'entête et le pied de page sur la documentation d'API du catalogue",
+      description: "Affiche la page de documentation de l'API du catalogue avec l'en-tête, la barre de navigation et le pied de page du portail plutôt qu'en mise en page minimale, pour un accès plus accessible (liens d'évitement, navigation, pied de page).",
       layout: 'switch'
     },
     authentication: {

--- a/portal/app/pages/catalog-api-doc.vue
+++ b/portal/app/pages/catalog-api-doc.vue
@@ -1,18 +1,65 @@
 <template>
+  <!-- Minimal layout (default): the API documentation iframe fills the whole viewport -->
   <d-frame-wrapper
-    :iframe-title="`${t('apiDoc')}`"
+    v-if="!keepPortalLayout"
+    :iframe-title="t('apiDoc')"
     :src="`/openapi-viewer/?urlType=catalog`"
     class="fill-height"
     resize="no"
     sync-params
   />
+
+  <!-- Portal layout kept: header, navigation and footer stay around the iframe
+       (RGAA 12.2/12.6/12.7). We reproduce the "full" layout's main/container chain so
+       the iframe fills the height (h-100 / fill-height), and expose the #contenu
+       skip-link target directly — deliberately without any breadcrumb. -->
+  <v-main v-else>
+    <div
+      id="contenu"
+      ref="contentEl"
+      tabindex="-1"
+      class="h-100"
+    >
+      <v-container
+        fluid
+        class="pa-0 h-100"
+      >
+        <d-frame-wrapper
+          :iframe-title="t('apiDoc')"
+          :src="`/openapi-viewer/?urlType=catalog`"
+          class="fill-height"
+          sync-params
+        />
+      </v-container>
+    </div>
+  </v-main>
 </template>
 
 <script setup lang="ts">
 definePageMeta({ layout: 'full' })
 
 const { setBreadcrumbs } = useNavigationStore()
+const { portalConfig } = usePortalStore()
 const { t } = useI18n()
+
+const keepPortalLayout = computed(() => portalConfig.value.catalogApiDocFullLayout)
+if (keepPortalLayout.value) setPageLayout('default')
+
+// the d-frame wrapper gets an inline "height: <content>px; min-height: 0" on each resize
+// message, so the iframe background stops with the content ; this shadow stylesheet wins
+// over the inline style and makes the iframe fill at least the available height while
+// still growing with the content
+const contentEl = useTemplateRef('contentEl')
+onMounted(async () => {
+  if (!keepPortalLayout.value) return
+  await customElements.whenDefined('d-frame')
+  const dFrame = contentEl.value?.querySelector('d-frame')
+  if (dFrame?.shadowRoot) {
+    const style = document.createElement('style')
+    style.textContent = '.d-frame-wrapper { min-height: 100% !important; }'
+    dFrame.shadowRoot.appendChild(style)
+  }
+})
 
 setBreadcrumbs([
   { type: 'standard', subtype: 'datasets' },


### PR DESCRIPTION
Add a portal configuration option (`catalogApiDocFullLayout`, Appearance tab, off by default) to render `/catalog-api-doc` with the standard portal layout instead of the minimal full-screen one.

When enabled, the page keeps the header, main navigation, footer and skip links (fixes RGAA 12.2 / 12.6 / 12.7 on this page), deliberately without a breadcrumb. The iframe fills at least the available height between header and footer, and still grows with its content (`resize` auto).

**Heads-up:**
- the min-height behavior is achieved by injecting a small stylesheet into the `d-frame` shadow root, because the lib rewrites an inline `height:<content>px; min-height:0` on the internal wrapper at every resize message and exposes no `::part`. This is meant to be transitional: the clean fix would be in `@data-fair/frame` (use `min-height:100%` on the wrapper — harmless when the host has an auto height — or expose a CSS part), after which this block can be removed.
- verified against a real `openapi-viewer` container in the dev stack: short content fills the viewport (background and nav divider reach the footer), tall content pushes the footer down.
