### PR TITLE
fix(page-element): constrain zoomed image overlay to the viewport

### DIFF
--- a/portal/app/components/page-element/basic/page-element-image.vue
+++ b/portal/app/components/page-element/basic/page-element-image.vue
@@ -81,6 +81,7 @@
     <img
       :alt="!element.isPresentation ? element.title : ''"
       :src="zoomedSrc"
+      class="zoom-overlay-img"
     >
   </v-overlay>
 </template>
@@ -162,5 +163,14 @@ const altLinkTitle = computed(() => {
 .banner-fluid {
   width: 100vw;
   margin-left: calc(50% - 50vw);
+}
+
+/* The zoomed image renders at its natural size: without these constraints,
+   an image wider than the window overflows the flex-centered overlay and
+   gets clipped on both sides. */
+.zoom-overlay-img {
+  max-width: 95vw;
+  max-height: 95vh;
+  object-fit: contain;
 }
 </style>


### PR DESCRIPTION
The zoomable image overlay rendered the image at its natural size: when the window is narrower than the image, it overflows the flex-centered `v-overlay` and gets clipped on both sides, with no way to scroll to the hidden parts. The zoomed image is now capped at `95vw`/`95vh` (scoped class, `object-fit: contain`), so it always fits the viewport with a margin left for the close-on-click-outside gesture.

**Why:** wide course screenshots (1440–2700px) were unreadable when zoomed in a non-fullscreen window (reported on docs.koumoul.com courses).

**Heads-up:** visual-only fix, no automated test — verify by zooming a wide image in a narrow window. The scoped style relies on the compile-time `data-v-*` attribute, which survives the Vuetify overlay teleport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
