### PR TITLE
fix(portal): forward embed ui-notif snackbars to the host queue

### DIFF
--- a/portal/app/components/d-frame-wrapper.vue
+++ b/portal/app/components/d-frame-wrapper.vue
@@ -3,12 +3,14 @@
     <d-frame
       v-bind="$attrs"
       .adapter="dFrameAdapter"
+      @notif="onNotif"
     />
   </ClientOnly>
 </template>
 
 <script setup lang="ts">
 import createDFrameAdapter from '@data-fair/frame/lib/vue-router/state-change-adapter.js'
+import { useUiNotif, type UiNotif } from '@data-fair/lib-vue/ui-notif.js'
 
 // inheritAttrs:false keeps unknown attrs (iframe-title, src, aspect-ratio) off the SSR <ClientOnly> placeholder
 defineOptions({ inheritAttrs: false })
@@ -16,4 +18,17 @@ defineOptions({ inheritAttrs: false })
 // <d-frame> is registered globally by plugins/dframe.client.ts — must run before any <d-frame> is created,
 // otherwise Vue's `.adapter` IDL binding is set on a not-yet-upgraded element and the constructor overwrites it.
 const dFrameAdapter = createDFrameAdapter(useRouter())
+
+// An embedded sub-app (data-fair, events, ...) delegates its ui-notif to the host when inside an iframe:
+// its own lib snackbar stays silent and posts the notif up, which <d-frame> re-dispatches as a `notif` event.
+// The event carries the flattened { type, title, detail } shape; rebuild the { msg, errorMsg, clientError }
+// shape sendUiNotif expects so error notifs keep their detail line (a naive { msg: title } drops it).
+const { sendUiNotif } = useUiNotif()
+const frameNotifArg = (notif: { type: string, title?: string, detail?: string }): UiNotif => {
+  if (notif.type === 'error' || notif.type === 'warning') {
+    return { type: 'error', msg: notif.title ?? '', errorMsg: notif.detail ?? notif.title ?? '', clientError: notif.type === 'warning' }
+  }
+  return { type: notif.type as 'default' | 'info' | 'success' | 'warning', msg: notif.title ?? notif.detail ?? '' }
+}
+const onNotif = (e: Event) => sendUiNotif(frameNotifArg((e as CustomEvent).detail))
 </script>

--- a/tests/features/ui/page-edit-webmcp.e2e.spec.ts
+++ b/tests/features/ui/page-edit-webmcp.e2e.spec.ts
@@ -33,16 +33,16 @@ test.describe('page edit WebMCP agent integration', () => {
     // Verify agent action button exists (hidden until a chat drawer responds via BroadcastChannel)
     await expect(page.locator('[data-action-id="configure-page"]')).toBeAttached()
 
-    // Verify WebMCP tools are registered via navigator.modelContext
-    const hasTools = await page.evaluate(() => {
+    // Verify WebMCP tools are registered via navigator.modelContext.
+    // Registration is async (dynamic compiled-layout import + registerTools),
+    // so poll until the tools appear rather than checking synchronously.
+    await page.waitForFunction(() => {
       const mc = (navigator as any).modelContext
       if (!mc || typeof mc.listTools !== 'function') return false
-      const tools = mc.listTools()
-      const toolNames = tools.map((t: any) => t.name)
+      const toolNames = mc.listTools().map((t: any) => t.name)
       return toolNames.includes('pageConfig_getData') &&
              toolNames.includes('pageConfig_setFieldValue')
-    })
-    expect(hasTools).toBe(true)
+    }, { timeout: 30_000 })
 
     // Test state sharing: use WebMCP callTool to change the title
     // The title field is at /$comp-1/title due to the layout section wrapper


### PR DESCRIPTION
Forward ui-notif snackbars from an embedded sub-app (data-fair, events, …) to the host portal's notification queue. Inside an iframe the sub-app's own lib snackbar stays silent and posts the notif up; `<d-frame>` re-dispatches it as a `notif` event, which `d-frame-wrapper` now listens to and forwards via `sendUiNotif`, rebuilding the `{ msg, errorMsg, clientError }` shape so error notifs keep their detail line.

**Why:** embed notifications were silently dropped — the portal never listened for the forwarded `notif` event anywhere.

Also waits for async WebMCP tool registration in the page-edit e2e test (`waitForFunction` instead of a synchronous `evaluate` assertion).
