### PR TITLE
fix(portal): distinct document title on content 404 pages (RGAA 8.6)

### DIFF
--- a/portal/app/components/page-error.vue
+++ b/portal/app/components/page-error.vue
@@ -71,6 +71,15 @@ const defaultTitles: Record<number, string> = {
 const title = computed(() => props.title || defaultTitles[props.statusCode] || t('error'))
 const headingTag = computed(() => (portalConfig.value.header?.show && portalConfig.value.header?.showTitle) ? 'h2' : 'h1')
 
+// Distinct document title per error type (RGAA 8.6). Registered after the page's
+// own usePageSeo so it wins over the generic page title.
+const tabTitles: Record<number, string> = {
+  404: t('tabNotFound'),
+  401: t('tabUnauthorized'),
+  403: t('tabForbidden')
+}
+useHead({ title: () => (tabTitles[props.statusCode] || t('tabError')) + ' - ' + portalConfig.value.title })
+
 const getErrorImageSrc = (type: 'notFound' | 'forbidden' | 'fallback') => {
   const image = portalConfig.value.errorImages?.[type]
   if (!image) return ''
@@ -85,10 +94,18 @@ const getErrorImageSrc = (type: 'notFound' | 'forbidden' | 'fallback') => {
     forbidden: You do not have permission to access this page.
     error: An unexpected error has occurred.
     goToHome: Go to Home
+    tabNotFound: Page not found
+    tabUnauthorized: Authentication required
+    tabForbidden: Access forbidden
+    tabError: Error
   fr:
     notFound: La page demandée n'existe pas.
     unauthorized: Vous devez être authentifié pour accéder à cette page.
     forbidden: Vous n'avez pas les droits pour accéder à cette page.
     error: Une erreur indéterminée s'est produite.
     goToHome: Aller à l'accueil
+    tabNotFound: Page introuvable
+    tabUnauthorized: Authentification requise
+    tabForbidden: Accès interdit
+    tabError: Erreur
 </i18n>

--- a/portal/app/components/page-error.vue
+++ b/portal/app/components/page-error.vue
@@ -49,6 +49,7 @@
 <script setup lang="ts">
 import type { LinkItem } from '#api/types/portal/index.js'
 import { mdiChevronLeft } from '@mdi/js'
+import { useHead } from '@unhead/vue'
 
 const props = defineProps<{
   statusCode: number

--- a/tests/features/portal-rendering/page-error-title.e2e.spec.ts
+++ b/tests/features/portal-rendering/page-error-title.e2e.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '../../fixtures/portal.ts'
+import { axiosAuth, clean } from '../../support/axios.ts'
+
+const user1 = await axiosAuth('test_admin@test.com')
+
+test.describe('content 404 document title', () => {
+  test.beforeEach(clean)
+
+  test('a missing content page gets a distinct document title', async ({ page, goToPortal }) => {
+    const portal = (await user1.post('/api/portals', {
+      config: { title: 'Erreur Portal', menu: { children: [] } }
+    })).data
+
+    await goToPortal(portal._id, '/pages/page-inexistante')
+    await expect(page).toHaveTitle('Page introuvable - Erreur Portal', { timeout: 10_000 })
+    await expect(page.getByRole('heading', { name: 'La page demandée n\'existe pas.' })).toBeVisible()
+  })
+})


### PR DESCRIPTION
The page-error component (content 404s rendered inside the portal layout) now sets a status-specific document title — « Page introuvable - {portal} », « Authentification requise - … », « Accès interdit - … » — following the same "X - portal title" pattern as every page. The bare error page (route 404s) already did this.

**Why:** RGAA 8.6 expects the document title of an error page to state the error; the audits flagged content 404s keeping the generic portal title.

**Heads-up:** the title is registered after the page's own `usePageSeo` and deliberately wins over it. Covered by a new `page-error-title` e2e spec; the title is present from SSR.
