### PR TITLE
fix(ui): dispose of vjsf mcp tools when leaving forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3081,9 +3081,9 @@
       }
     },
     "node_modules/@koumoul/vjsf-compiler": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@koumoul/vjsf-compiler/-/vjsf-compiler-1.5.0.tgz",
-      "integrity": "sha512-EpqwL2XFSWKohpjYoqq1LpSLBlidnjUjV27cYzhv7hmu6wsKDTw5TUZE9DWqbV6O6XAaOTbyLdN2Bx8EN1P3+w==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@koumoul/vjsf-compiler/-/vjsf-compiler-1.5.1.tgz",
+      "integrity": "sha512-fvUXXjuvhPPCyp04HKe7jcp+XZ8ZMZBWaAfQyLar50mybUXdT/OYRasdDOIod6IRreLeRHO9zI6pn7Y7A5ih2A==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/ui/src/composables/use-page-config-webmcp.ts
+++ b/ui/src/composables/use-page-config-webmcp.ts
@@ -1,4 +1,4 @@
-import { computed, shallowRef, watch, toRaw, type Ref } from 'vue'
+import { computed, shallowRef, watch, toRaw, onScopeDispose, type Ref } from 'vue'
 import { StatefulLayout } from '@json-layout/core/state'
 import { WebMCP } from '@json-layout/core/webmcp'
 import equal from 'fast-deep-equal'
@@ -51,7 +51,14 @@ export function usePageConfigWebMCP (
         sl as any,
         { prefixName: 'pageConfig_', dataTitle: 'Page configuration', includeSubAgent: true }
       )
-      await wm.registerTools()
+      try {
+        await wm.registerTools()
+      } catch (e) {
+        // a failed registerTools may leave some tools registered; release them so
+        // the global navigator.modelContext registry is not poisoned for retries
+        await wm.unregisterTools().catch(() => {})
+        throw e
+      }
       webMCP.value = wm
     } catch (e) {
       console.error('[usePageConfigWebMCP] setup error', e)
@@ -59,6 +66,16 @@ export function usePageConfigWebMCP (
       setupInProgress = false
     }
   }
+
+  // navigator.modelContext is a page-lifetime global registry that throws on
+  // duplicate names: tools must be released when the owning component unmounts,
+  // otherwise the next mount fails with "Tool already registered"
+  onScopeDispose(() => {
+    if (webMCP.value) {
+      webMCP.value.unregisterTools().catch((e: any) => console.error('[usePageConfigWebMCP] unregister error', e))
+      webMCP.value = null
+    }
+  })
 
   // Load compiled layout when locale changes
   watch(locale, async (loc) => {


### PR DESCRIPTION
Unregister the VJSF WebMCP tools when the component owning `usePageConfigWebMCP` unmounts, and clean up partial registrations when `registerTools()` fails.

**Why:** `navigator.modelContext` is a page-lifetime global registry that throws on duplicate names. Without disposal, leaving the page-config form and coming back failed with "Tool already registered", leaving the agent without its form tools.