### PR TITLE
fix(ui): heal page configs rejected by the schema and report unhealable errors

### DIFF
--- a/api/types/page-config/schema.js
+++ b/api/types/page-config/schema.js
@@ -1,7 +1,13 @@
 export default {
   $id: 'https://github.com/data-fair/portals/page-config',
-  'x-exports': ['types', 'vjsf'],
+  'x-exports': ['types', 'vjsf', 'validate'],
   'x-jstt': { additionalProperties: false },
+  // the validate export MUTATES its input: removeAdditional strips the properties that
+  // violate additionalProperties, so that configs carrying leftovers of old element type
+  // switches can be healed instead of blocking the page editor. The discriminator option
+  // is required for this to be safe: without it the properties of the matching branch of
+  // the elements oneOf would be removed as additional properties of the other branches.
+  'x-ajv': { discriminator: true, removeAdditional: true },
   'x-vjsf': {
     pluginsImports: ['@koumoul/vjsf-markdown'],
     xI18n: true,

--- a/tests/features/ui/page-config-clean.unit.spec.ts
+++ b/tests/features/ui/page-config-clean.unit.spec.ts
@@ -1,0 +1,76 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+// @ts-ignore generated export
+import { validate } from '../../../api/types/page-config/index.ts'
+
+// The page-config validate export is compiled with removeAdditional (see the x-ajv
+// comment in the schema): it strips the properties that violate additionalProperties
+// from its input. The page editor relies on it to heal stored configs, so these tests
+// pin that behavior down.
+
+// Reduced from a real page that made the editor inert: a title element carrying a mb
+// property, which the element-title schema never allowed (leftover of an old element
+// type switch, then copied around by page duplication).
+const brokenConfig = () => ({
+  title: 'test',
+  elements: [
+    {
+      uuid: 'a0000001',
+      type: 'banner',
+      mb: 4,
+      fullWidth: true,
+      background: { color: 'secondary' },
+      children: [
+        {
+          uuid: 'a0000002',
+          type: 'card',
+          mb: 0,
+          actions: [],
+          children: [
+            { uuid: 'a0000003', type: 'text', centered: true, mb: 0, content: 'hello' },
+            { uuid: 'a0000004', type: 'title', titleSize: 'h5', titleTag: 'h1', content: 'hi', mb: 0 }
+          ]
+        }
+      ]
+    }
+  ],
+  genericMetadata: { slug: 'test' }
+})
+
+const healedConfig = () => {
+  const config = brokenConfig()
+  delete (config.elements[0].children[0].children[1] as any).mb
+  return config
+}
+
+test.describe('page config validation heals stale properties', () => {
+  test('strips the stale property and validates', () => {
+    const config = brokenConfig()
+    assert.equal(validate(config), true)
+    assert.deepEqual(config, healedConfig())
+  })
+
+  test('does not touch the properties of the matching oneOf branches', () => {
+    // valid properties of the tagged branches are "additional" from the point of view
+    // of the non-matching branches, the discriminator option must protect them
+    const config = brokenConfig()
+    validate(config)
+    const card = (config as any).elements[0].children[0]
+    assert.equal(card.mb, 0)
+    assert.equal(card.children[0].content, 'hello')
+    assert.equal(card.children[0].mb, 0)
+    assert.equal(card.children[1].titleSize, 'h5')
+  })
+
+  test('leaves a valid config identical', () => {
+    const config = healedConfig()
+    assert.equal(validate(config), true)
+    assert.deepEqual(config, healedConfig())
+  })
+
+  test('does not heal other error classes', () => {
+    const config = healedConfig()
+    delete (config.elements[0].children[0].children[1] as any).titleSize
+    assert.equal(validate(config), false, 'a missing required property cannot be healed by removals')
+  })
+})

--- a/tests/features/ui/page-edit-heal.e2e.spec.ts
+++ b/tests/features/ui/page-edit-heal.e2e.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '../../fixtures/login.ts'
+import { axiosAuth, clean } from '../../support/axios.ts'
+import { MongoClient } from 'mongodb'
+
+const user1 = await axiosAuth('test_admin@test.com')
+
+// Create a valid page through the API then inject legacy data directly in mongo:
+// the current API rejects such configs, but old versions of the editor stored them
+// (typically leftovers of an element type switch) and page duplication copied them
+// around. The page editor must keep working on them.
+// The e2e stack always runs against the dev API server, hence the development database.
+const injectLegacyData = async (pageId: string, mongoPatch: Record<string, any>) => {
+  const client = await MongoClient.connect(`mongodb://localhost:${process.env.MONGO_PORT}/data-fair-portals-development`)
+  try {
+    const result = await client.db().collection('pages').updateOne({ _id: pageId as any }, mongoPatch)
+    if (result.matchedCount !== 1) throw new Error(`mongo legacy data injection matched ${result.matchedCount} pages`)
+  } finally {
+    await client.close()
+  }
+}
+
+const createPage = async () => {
+  const portal = (await user1.post('/api/portals', {
+    config: { title: 'Heal Test Portal', menu: { children: [] } }
+  })).data
+
+  return (await user1.post('/api/pages', {
+    type: 'generic',
+    config: {
+      title: 'Heal Test Page',
+      elements: [{ uuid: 'el000001', type: 'title', titleSize: 'h3', content: 'hello title' }],
+      genericMetadata: { slug: 'heal-test' }
+    },
+    portals: [portal._id],
+    owner: portal.owner
+  })).data
+}
+
+test.describe('page editor on legacy configs rejected by the schema', () => {
+  test.beforeEach(clean)
+
+  test('heals stale properties and saves the draft again', async ({ page, goToWithAuth }) => {
+    // mb was never accepted on title elements, this reproduces the real stored data
+    // that made the editor inert (grey draft buttons, edits silently dropped)
+    const createdPage = await createPage()
+    await injectLegacyData(createdPage._id, {
+      $set: { 'config.elements.0.mb': 0, 'draftConfig.elements.0.mb': 0 }
+    })
+    const injected = (await user1.get(`/api/pages/${createdPage._id}`)).data
+    expect(injected.draftConfig.elements[0].mb).toBe(0)
+
+    await goToWithAuth(`/portals-manager/pages/${createdPage._id}/edit-config`, 'test_admin')
+    await expect(page.getByLabel('Titre')).toBeVisible({ timeout: 30_000 })
+
+    // the stale property is healed on load, no config error is reported
+    await expect(page.getByRole('alert').filter({ hasText: 'La configuration de la page contient des erreurs' })).toHaveCount(0)
+
+    // an edit must reach the API again (this used to be silently dropped)
+    const patchResponse = page.waitForResponse(response =>
+      response.url().includes(`/api/pages/${createdPage._id}`) &&
+      response.request().method() === 'PATCH' &&
+      response.ok()
+    )
+    await page.getByLabel('Titre').fill('Heal Test Page renamed')
+    await page.getByLabel('Titre').blur()
+    await patchResponse
+
+    // the draft now differs from the published config, the draft actions activate
+    await expect(page.locator('.v-list-item', { hasText: 'Valider le brouillon' })).not.toHaveClass(/v-list-item--disabled/)
+
+    // the saved draft is the healed one
+    const saved = (await user1.get(`/api/pages/${createdPage._id}`)).data
+    expect(saved.draftConfig.elements[0].mb).toBeUndefined()
+    expect(saved.draftConfig.title).toBe('Heal Test Page renamed')
+  })
+
+  test('reports the errors it cannot heal instead of silently blocking saves', async ({ page, goToWithAuth }) => {
+    // a wrong value type cannot be healed by removals nor by schema defaults, and the
+    // form does not display errors carried by page elements, so the editor reports them
+    // in a dedicated alert
+    const createdPage = await createPage()
+    await injectLegacyData(createdPage._id, {
+      $set: { 'config.elements.0.content': 42, 'draftConfig.elements.0.content': 42 }
+    })
+
+    await goToWithAuth(`/portals-manager/pages/${createdPage._id}/edit-config`, 'test_admin')
+    await expect(page.getByLabel('Titre')).toBeVisible({ timeout: 30_000 })
+
+    const alert = page.getByRole('alert').filter({ hasText: 'La configuration de la page contient des erreurs' })
+    await expect(alert).toBeVisible()
+    await expect(alert).toContainText('/elements/0/content')
+  })
+})

--- a/ui/src/components/page-edit/page-config-errors.vue
+++ b/ui/src/components/page-edit/page-config-errors.vue
@@ -19,23 +19,10 @@
 </template>
 
 <script setup lang="ts">
-import type { PageConfig } from '#api/types/page/index.ts'
-import type { ErrorObject } from 'ajv'
-import { validate as validatePageConfig } from '#api/types/page-config/index.ts'
-
+// Lists the errors of the STORED page config that could not be healed when it was
+// loaded. Errors introduced while editing are the responsibility of the form itself.
 const { t } = useI18n()
-const { config } = defineProps<{ config: PageConfig | undefined }>()
-
-// the config was healed of removable properties when it was loaded, the remaining
-// errors cannot be fixed automatically and the form does not display the ones carried
-// by page elements, but they block the draft saves, so they must be listed here
-const errors = computed(() => {
-  if (!config) return []
-  const clone = structuredClone(toRaw(config))
-  if (validatePageConfig(clone)) return []
-  const validationErrors = (validatePageConfig as unknown as { errors?: ErrorObject[] | null }).errors ?? []
-  return [...new Set(validationErrors.map(error => `${error.instancePath} ${error.message}`))]
-})
+const { errors } = defineProps<{ errors: string[] }>()
 </script>
 
 <i18n lang="yaml">

--- a/ui/src/components/page-edit/page-config-errors.vue
+++ b/ui/src/components/page-edit/page-config-errors.vue
@@ -1,0 +1,46 @@
+<template>
+  <v-alert
+    v-if="errors.length"
+    type="warning"
+    density="compact"
+    variant="tonal"
+    class="mb-4"
+    :title="t('title')"
+  >
+    <ul class="ml-4">
+      <li
+        v-for="error of errors"
+        :key="error"
+      >
+        <code>{{ error }}</code>
+      </li>
+    </ul>
+  </v-alert>
+</template>
+
+<script setup lang="ts">
+import type { PageConfig } from '#api/types/page/index.ts'
+import type { ErrorObject } from 'ajv'
+import { validate as validatePageConfig } from '#api/types/page-config/index.ts'
+
+const { t } = useI18n()
+const { config } = defineProps<{ config: PageConfig | undefined }>()
+
+// the config was healed of removable properties when it was loaded, the remaining
+// errors cannot be fixed automatically and the form does not display the ones carried
+// by page elements, but they block the draft saves, so they must be listed here
+const errors = computed(() => {
+  if (!config) return []
+  const clone = structuredClone(toRaw(config))
+  if (validatePageConfig(clone)) return []
+  const validationErrors = (validatePageConfig as unknown as { errors?: ErrorObject[] | null }).errors ?? []
+  return [...new Set(validationErrors.map(error => `${error.instancePath} ${error.message}`))]
+})
+</script>
+
+<i18n lang="yaml">
+  en:
+    title: The page configuration contains errors, the changes cannot be saved until they are fixed
+  fr:
+    title: La configuration de la page contient des erreurs, les modifications ne peuvent pas être enregistrées tant qu'elles ne sont pas corrigées
+</i18n>

--- a/ui/src/pages/pages/[pageId]/edit-config.vue
+++ b/ui/src/pages/pages/[pageId]/edit-config.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container data-iframe-height>
-    <page-config-errors :config="editConfig" />
+    <page-config-errors :errors="storedConfigErrors" />
     <portal-preview-provider>
       <v-form
         v-if="editConfig"
@@ -55,6 +55,7 @@
 <script lang="ts" setup>
 import type { Options as VjsfOptions } from '@koumoul/vjsf'
 import type { Page, Group, PageConfig } from '#api/types/page/index.ts'
+import type { ErrorObject } from 'ajv'
 
 import equal from 'fast-deep-equal'
 import { validate as validatePageConfig } from '#api/types/page-config/index.ts'
@@ -70,6 +71,9 @@ const pageRef = { type: 'page' as const, _id: inject('page-id') as string }
 const { pageFetch, patchPage } = usePageStore()
 
 const editConfig = ref<PageConfig>()
+// errors of the stored config that healing could not fix, they block the draft saves
+// and the form does not display the ones carried by page elements
+const storedConfigErrors = ref<string[]>([])
 watch(pageFetch.data, () => {
   if (!pageFetch.data.value) return
   // old configs can carry properties that the schema rejects (leftovers of an element
@@ -77,7 +81,12 @@ watch(pageFetch.data, () => {
   // start and saving the draft would be silently blocked. The validate function is
   // compiled with removeAdditional and strips them from its input.
   const draftConfig = structuredClone(toRaw(pageFetch.data.value.draftConfig))
-  validatePageConfig(draftConfig)
+  if (validatePageConfig(draftConfig)) {
+    storedConfigErrors.value = []
+  } else {
+    const validationErrors = (validatePageConfig as unknown as { errors?: ErrorObject[] | null }).errors ?? []
+    storedConfigErrors.value = [...new Set(validationErrors.map(error => `${error.instancePath} ${error.message}`))]
+  }
   if (!equal(draftConfig, toRaw(pageFetch.data.value.draftConfig))) console.warn('removed properties rejected by the page config schema')
   if (equal(toRaw(editConfig.value), draftConfig)) return
   editConfig.value = draftConfig
@@ -166,6 +175,8 @@ const vjsfDefaults = {
 const saveDraft = useAsyncAction(async () => {
   if (!formValid.value) return
   await patchPage.execute({ draftConfig: editConfig.value })
+  // the stored draft was accepted by the API, it no longer carries errors
+  storedConfigErrors.value = []
 })
 
 const { configureContext } = usePageConfigWebMCP(editConfig, locale, (data: any) => {

--- a/ui/src/pages/pages/[pageId]/edit-config.vue
+++ b/ui/src/pages/pages/[pageId]/edit-config.vue
@@ -1,5 +1,6 @@
 <template>
   <v-container data-iframe-height>
+    <page-config-errors :config="editConfig" />
     <portal-preview-provider>
       <v-form
         v-if="editConfig"
@@ -56,6 +57,7 @@ import type { Options as VjsfOptions } from '@koumoul/vjsf'
 import type { Page, Group, PageConfig } from '#api/types/page/index.ts'
 
 import equal from 'fast-deep-equal'
+import { validate as validatePageConfig } from '#api/types/page-config/index.ts'
 import { renderMarkdown } from '@data-fair/portals-shared-markdown'
 import NavigationRight from '@data-fair/lib-vuetify/navigation-right.vue'
 import { DfAgentChatAction } from '@data-fair/lib-vuetify-agents'
@@ -70,8 +72,15 @@ const { pageFetch, patchPage } = usePageStore()
 const editConfig = ref<PageConfig>()
 watch(pageFetch.data, () => {
   if (!pageFetch.data.value) return
-  if (equal(toRaw(editConfig.value), pageFetch.data.value.draftConfig)) return
-  editConfig.value = pageFetch.data.value.draftConfig
+  // old configs can carry properties that the schema rejects (leftovers of an element
+  // type switch, propagated by page duplication), the form would be invalid from the
+  // start and saving the draft would be silently blocked. The validate function is
+  // compiled with removeAdditional and strips them from its input.
+  const draftConfig = structuredClone(toRaw(pageFetch.data.value.draftConfig))
+  validatePageConfig(draftConfig)
+  if (!equal(draftConfig, toRaw(pageFetch.data.value.draftConfig))) console.warn('removed properties rejected by the page config schema')
+  if (equal(toRaw(editConfig.value), draftConfig)) return
+  editConfig.value = draftConfig
 }, { immediate: true })
 provide('page-config', editConfig)
 

--- a/ui/src/pages/pages/[pageId]/edit-simple.vue
+++ b/ui/src/pages/pages/[pageId]/edit-simple.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container data-iframe-height>
-    <page-config-errors :config="editConfig" />
+    <page-config-errors :errors="storedConfigErrors" />
     <v-form
       v-if="editConfig"
       v-model="formValid"
@@ -44,6 +44,7 @@
 <script lang="ts" setup>
 import type { Options as VjsfOptions } from '@koumoul/vjsf'
 import type { Page, Group, PageConfig } from '#api/types/page/index.ts'
+import type { ErrorObject } from 'ajv'
 
 import { validate as validatePageConfig } from '#api/types/page-config/index.ts'
 import { renderMarkdown } from '@data-fair/portals-shared-markdown'
@@ -57,6 +58,9 @@ const pageRef = { type: 'page' as const, _id: inject('page-id') as string }
 const { pageFetch, patchPage } = usePageStore()
 
 const editConfig = ref<PageConfig>()
+// errors of the stored config that healing could not fix, they block the draft saves
+// and the form does not display the ones carried by page elements
+const storedConfigErrors = ref<string[]>([])
 watch(pageFetch.data, () => {
   if (!pageFetch.data.value) return
   // old configs can carry properties that the schema rejects (leftovers of an element
@@ -64,7 +68,12 @@ watch(pageFetch.data, () => {
   // start and saving the draft would be silently blocked. The full page-config validate
   // function is compiled with removeAdditional and strips them from its input.
   const draftConfig = structuredClone(toRaw(pageFetch.data.value.draftConfig))
-  validatePageConfig(draftConfig)
+  if (validatePageConfig(draftConfig)) {
+    storedConfigErrors.value = []
+  } else {
+    const validationErrors = (validatePageConfig as unknown as { errors?: ErrorObject[] | null }).errors ?? []
+    storedConfigErrors.value = [...new Set(validationErrors.map(error => `${error.instancePath} ${error.message}`))]
+  }
   editConfig.value = draftConfig
 }, { immediate: true })
 provide('page-config', editConfig)
@@ -149,6 +158,8 @@ const vjsfOptions = computed<VjsfOptions>(() => ({
 const saveDraft = useAsyncAction(async () => {
   if (!formValid.value) return
   await patchPage.execute({ draftConfig: editConfig.value })
+  // the stored draft was accepted by the API, it no longer carries errors
+  storedConfigErrors.value = []
 })
 
 watch(pageFetch.data, (page) => {

--- a/ui/src/pages/pages/[pageId]/edit-simple.vue
+++ b/ui/src/pages/pages/[pageId]/edit-simple.vue
@@ -1,5 +1,6 @@
 <template>
   <v-container data-iframe-height>
+    <page-config-errors :config="editConfig" />
     <v-form
       v-if="editConfig"
       v-model="formValid"
@@ -44,6 +45,7 @@
 import type { Options as VjsfOptions } from '@koumoul/vjsf'
 import type { Page, Group, PageConfig } from '#api/types/page/index.ts'
 
+import { validate as validatePageConfig } from '#api/types/page-config/index.ts'
 import { renderMarkdown } from '@data-fair/portals-shared-markdown'
 import NavigationRight from '@data-fair/lib-vuetify/navigation-right.vue'
 import { DfAgentChatAction } from '@data-fair/lib-vuetify-agents'
@@ -56,7 +58,14 @@ const { pageFetch, patchPage } = usePageStore()
 
 const editConfig = ref<PageConfig>()
 watch(pageFetch.data, () => {
-  if (pageFetch.data.value) editConfig.value = pageFetch.data.value.draftConfig
+  if (!pageFetch.data.value) return
+  // old configs can carry properties that the schema rejects (leftovers of an element
+  // type switch, propagated by page duplication), the form would be invalid from the
+  // start and saving the draft would be silently blocked. The full page-config validate
+  // function is compiled with removeAdditional and strips them from its input.
+  const draftConfig = structuredClone(toRaw(pageFetch.data.value.draftConfig))
+  validatePageConfig(draftConfig)
+  editConfig.value = draftConfig
 }, { immediate: true })
 provide('page-config', editConfig)
 


### PR DESCRIPTION
Old page configs can carry properties that no current schema version accepts — typically leftovers of an element type switch saved by pre-2.18 editors, then copied around by page duplication. The editors validate with `initialValidation: 'always'` and silently skip the draft PATCH when the form is invalid, so such a page became fully inert: edits dropped, draft buttons grey, no visible error (the form does not display errors carried by elements rendered through the preview slot).

**What changed**
- The `page-config` schema now exports a `validate` function compiled with ajv `removeAdditional` + `discriminator`: it strips the properties that violate `additionalProperties` from its input. The discriminator option is what makes this safe — without it, `allErrors` mode reports the matching oneOf branch's own properties as "additional" on the other branches and the stripping would destroy valid data.
- Both page editors (`edit-config`, `edit-simple`) run it on the fetched draft, so stale properties are healed on load and the next edit saves a clean config.
- The errors of the *stored* config that removals cannot heal (e.g. wrong value types) are captured once at draft load and listed in a new `page-config-errors` alert instead of silently blocking saves; the list clears when a save is accepted. Errors introduced while editing remain the form's responsibility.
- 4 unit tests pin the validate behavior; 2 e2e tests inject real legacy data directly in mongo (the API rightly rejects it) and check the editor heals + saves again, and reports unhealable errors.

**Why:** a staging page (duplicated from a legacy page whose title elements carried a stale `mb` property) had become impossible to edit, with no feedback anywhere.

**Regression risks**
- The `validate` export **mutates its input** — future importers of `validate`/`assertValid`/`returnValid` from this module get stripping semantics. Documented in the schema, single consumer today.
- Healing deletes schema-rejected data by design; in a rollback window (data written by a newer schema) forward-compatible properties would be stripped and persisted on the next edit.
- Live vjsf form validation is untouched (`removeAdditional` is in `x-ajv`, not `x-vjsf.ajvOptions`), and stored-config errors are computed only at draft load, not during editing.
- The e2e spec assumes the dev API's `data-fair-portals-development` database; the injection fails loudly (matchedCount guard) if that assumption ever breaks.
