### PR TITLE
feat(page-element): topic chip hover effects per mode

### DIFF
--- a/api/types/common-defs/schema.ts
+++ b/api/types/common-defs/schema.ts
@@ -21,6 +21,20 @@ const makeHoverConfig = (colorRef: string) => ({
   }
 })
 
+// Topics are only clickable as a link to the catalog or as a toggle filter, and the second mode
+// paints its own state, hence a distinct effects list per mode (see hoverConfigTopics).
+const topicsEffectTitles: Record<string, string> = {
+  darken: 'Assombrissement',
+  elevate: 'Élévation',
+  grow: 'Agrandissement',
+  background: 'Couleur de fond',
+  border: 'Colorer le bord',
+  invert: 'Inversion du remplissage'
+}
+const topicsEffectItems = (...keys: string[]) => keys.map(key => ({ key, title: topicsEffectTitles[key] }))
+// Same condition as the `variant` property of the topics element: redirection needs a single source.
+const topicsLinkMode = 'parent.parent?.data?.redirectPage && (!Array.isArray(parent.parent?.data?.mode) || parent.parent?.data?.mode.length <= 1)'
+
 export default {
   $id: 'https://github.com/data-fair/portals/common-defs',
   'x-exports': ['types'],
@@ -110,7 +124,8 @@ export default {
     // Hover config with the extended color palette, matching the box background colors.
     hoverConfigFull: makeHoverConfig('#/$defs/color-full'),
 
-    // Topics hover config: applies to clickable topics only; filter mode ignores background/border.
+    // Topics hover config: applies to clickable topics only; the offered effects depend on the
+    // mode, filter chips already encoding their selection through their fill.
     hoverConfigTopics: {
       type: 'object',
       title: 'Effets au survol',
@@ -118,24 +133,27 @@ export default {
         effects: {
           type: 'array',
           title: 'Effets',
-          description: 'Appliqués quand les thématiques sont cliquables (lien ou filtre). En mode filtre, la coloration du fond et du bord est ignorée. Par défaut, le style du portail est hérité.',
+          description: 'Appliqués quand les thématiques sont cliquables (redirection ou filtre). Seuls les effets cochés sont appliqués ; sans sélection, ce sont les effets du portail qui sont hérités. En mode filtre, « Inversion du remplissage » remplit au survol une thématique inactive et vide une thématique active.',
+          layout: {
+            // json-layout only derives the options from the oneOf when the layout provides none,
+            // so each case offers the effects that actually do something in that mode.
+            switch: [
+              { if: topicsLinkMode, items: topicsEffectItems('darken', 'elevate', 'grow', 'background', 'border') },
+              { items: topicsEffectItems('darken', 'elevate', 'grow', 'border', 'invert') }
+            ]
+          },
           items: {
             type: 'string',
-            oneOf: [
-              { const: 'darken', title: 'Assombrissement' },
-              { const: 'elevate', title: 'Élévation' },
-              { const: 'grow', title: 'Agrandissement' },
-              { const: 'background', title: 'Couleur de fond' },
-              { const: 'border', title: 'Colorer le bord' }
-            ]
+            // every value stays valid in both modes so switching mode never invalidates a config
+            oneOf: Object.entries(topicsEffectTitles).map(([value, title]) => ({ const: value, title }))
           }
         },
         color: {
           $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/color-topics',
           title: 'Couleur de survol',
           layout: {
-            // Only in link mode (same condition as `variant`): filter chips ignore background/border effects.
-            if: "parent.parent?.data?.redirectPage && (!Array.isArray(parent.parent?.data?.mode) || parent.parent?.data?.mode.length <= 1) && parent.data?.effects?.some(e => ['background', 'border'].includes(e))",
+            // "border" colors the outline in both modes, "background" only fills in link mode
+            if: `parent.data?.effects?.includes('border') || ((${topicsLinkMode}) && parent.data?.effects?.includes('background'))`,
             slots: {
               item: { name: 'color-select-item' },
               selection: { name: 'color-select-selection' }

--- a/api/types/page-element-functional/schema.js
+++ b/api/types/page-element-functional/schema.js
@@ -201,7 +201,10 @@ export default {
         elevation: { $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/elevation' },
         density: { $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/density' },
         rounded: { $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/rounded' },
-        hover: { $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/hoverConfigTopics' },
+        hover: {
+          $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/hoverConfigTopics',
+          layout: { comp: 'card' }
+        },
         variant: {
           $ref: 'https://github.com/data-fair/portals/common-defs#/$defs/variant',
           layout: { if: 'parent.data?.redirectPage && (!Array.isArray(parent.data?.mode) || parent.data?.mode.length <= 1)' }

--- a/portal/app/components/topics-list.vue
+++ b/portal/app/components/topics-list.vue
@@ -11,8 +11,8 @@
     >
       <!--
         :to => redirect to the dataset page
-        :link => interactive (overlay/ripple) when link or filter; color-based hover effects (background/border) are excluded in filter mode
-        :variant => flat when selected, outlined when not
+        :link => interactive (overlay/ripple) when link or filter; the background hover effect is excluded in filter mode, where 'invert' takes over
+        :variant => flat when selected, outlined when not, flipped on hover with the 'invert' effect
         :style => surface background + consistent border width
         label => use default button rounding, not default chip rounding
         @click => toggle selection in query param
@@ -29,14 +29,14 @@
           :rounded="config?.rounded ?? portalConfig.defaults?.rounded"
           :link="isFilters || !!link"
           :to="(!preview && link && !isExternalLink(link)) ? `${resolveLink(link)}?topics=${topic.id}` : undefined"
-          :variant="chipVariant(topic.id)"
-          :style="[chipStyle(topic.id, topic.color), chipHoverStyle(topic, isHovering)]"
+          :variant="chipVariant(topic.id, isHovering)"
+          :style="[chipStyle(topic.id, topic.color, isHovering), chipHoverStyle(topic, isHovering)]"
           label
           @click="toggle(topic.id)"
         >
           <v-icon
             v-if="config?.showIcon && (topic.icon?.svgPath || topic.icon?.svg)"
-            :color="resolvedIconColor(topic.id, topic.color)"
+            :color="resolvedIconColor(topic.id, topic.color, isHovering)"
             :icon="topic.icon?.svgPath || extractSvgPath(topic.icon?.svg)"
             start
           />
@@ -74,9 +74,9 @@ const { isFilters, config, link } = defineProps<{
 }>()
 
 const chipEffects: HoverEffect[] = ['darken', 'elevate', 'background', 'border', 'grow']
-// As filters, chips encode selection through color, so color-based effects would
-// clash: keep only the color-neutral ones.
-const filterEffects: HoverEffect[] = ['darken', 'elevate', 'grow']
+// As filters, chips already encode selection through their fill, so filling them on hover
+// would clash: 'invert' flips that fill instead, which doubles as the toggle feedback.
+const filterEffects: HoverEffect[] = ['darken', 'elevate', 'grow', 'border', 'invert']
 // The reserved border can't match a tonal background, so exclude the border effect there.
 const relevantEffects = computed<HoverEffect[]>(() => {
   if (isFilters) return filterEffects
@@ -89,14 +89,21 @@ const hoverInteractive = computed(() => isFilters || !!link)
 // The 'default' hover color means each topic's own color (raw CSS color, not a theme name).
 const chipHoverStyle = (topic: { id: string, color?: string }, isHovering: boolean | null): Record<string, string> | undefined => {
   if (!hoverInteractive.value) return undefined
-  const style = hoverFx.rootStyle(isHovering, { hasBorder: chipVariant(topic.id) === 'outlined' || isSelected(topic.id), inlineBackground: true, small: true })
-  if (style && hoverFx.resolved.value.color === 'default') {
+  const outlined = chipVariant(topic.id, isHovering) === 'outlined'
+  const { effects, color } = hoverFx.resolved.value
+  const style = hoverFx.rootStyle(isHovering, { hasBorder: outlined || isFilters, inlineBackground: true, small: true })
+  if (style && color === 'default') {
     const topicColor = topic.color ?? 'rgb(var(--v-theme-primary))'
     if (style.borderColor) style.borderColor = topicColor
     if (style.backgroundColor) {
       style.backgroundColor = topicColor
       delete style.color
     }
+  }
+  // An outlined chip draws its border from currentColor, which the fill's text color would
+  // drag along: pin it back to the resting color unless 'border' is meant to repaint it.
+  if (style && outlined && effects.includes('background') && !effects.includes('border')) {
+    style.borderColor = restingColor(topic.color)
   }
   return style
 }
@@ -111,26 +118,37 @@ const toggle = (id: string) => {
 // Selection is only meaningful when used as filters.
 const isSelected = (id: string): boolean => isFilters && selected.value.includes(id)
 
+// The 'invert' effect swaps the fill of the hovered chip: an inactive filter looks selected,
+// an active one looks unselected, which previews what the click is about to do.
+const isInverted = (isHovering: boolean | null) => !!isHovering && hoverFx.resolved.value.effects.includes('invert')
+
 /*
  * Variant behavior:
- * - If filters: use selection behavior (selected=flat, not selected=outlined).
+ * - If filters: use selection behavior (selected=flat, not selected=outlined), inverted on hover.
  * - If config.variant === 'default': use undefined (Vuetify default).
  * - Otherwise: use configured variant.
  */
-const chipVariant = (topicId: string) => {
-  if (isFilters) return isSelected(topicId) ? 'flat' : 'outlined'
+const chipVariant = (topicId: string, isHovering: boolean | null) => {
+  if (isFilters) return isSelected(topicId) !== isInverted(isHovering) ? 'flat' : 'outlined'
   if (!config?.variant || config.variant === 'default') return 'flat'
   return config.variant
 }
 
-// Keep surface background and consistent width (by adding transparent border) when filters are enabled and not selected.
-const chipStyle = (topicId: string, topicColor?: string): Record<string, string> | undefined => {
-  if (isSelected(topicId)) return { border: '1px solid transparent' }
-  if (chipVariant(topicId) !== 'outlined') return undefined
+// Keep surface background on outlined chips, and consistent width (by adding transparent border)
+// on the filled ones they sit next to when filters are enabled.
+const chipStyle = (topicId: string, topicColor: string | undefined, isHovering: boolean | null): Record<string, string> | undefined => {
+  if (chipVariant(topicId, isHovering) !== 'outlined') return isFilters ? { border: '1px solid transparent' } : undefined
 
   const style: Record<string, string> = { backgroundColor: 'rgb(var(--v-theme-surface))' }
   if (!resolvedColor(topicColor)) style.color = 'rgb(var(--v-theme-on-surface))'
   return style
+}
+
+/** The CSS color a chip shows at rest, which its outlined border inherits through currentColor. */
+const restingColor = (topicColor?: string): string => {
+  const color = resolvedColor(topicColor)
+  if (!color) return 'rgb(var(--v-theme-on-surface))'
+  return config?.color === 'default' ? color : `rgb(var(--v-theme-${color}))`
 }
 
 /**
@@ -148,10 +166,10 @@ const resolvedColor = (topicColor?: string): string | undefined => {
  * 'default' => use topic color
  * Any other value => use configured color.
  *
- * Default text color if selected
+ * A filled filter chip keeps the contrast color Vuetify computes for its content.
  */
-const resolvedIconColor = (topicId: string, topicColor?: string): string | undefined => {
-  if (isSelected(topicId)) return undefined
+const resolvedIconColor = (topicId: string, topicColor: string | undefined, isHovering: boolean | null): string | undefined => {
+  if (isFilters && chipVariant(topicId, isHovering) !== 'outlined') return undefined
   if (!config?.iconColor) return undefined
   return config.iconColor === 'default' ? topicColor : config.iconColor
 }

--- a/portal/app/utils/hover.ts
+++ b/portal/app/utils/hover.ts
@@ -1,11 +1,12 @@
 // Relative (not the portal's #api alias) so this file still resolves under the
 // root tsconfig that type-checks the unit test importing it — that config has no
 // #api alias, and the tests import api types relatively too.
-import type { Effects as SchemaHoverEffects, ButtonConfig } from '../../../api/types/common-defs/index.ts'
+import type { Effects as SchemaHoverEffects, Effets as SchemaTopicsEffects, ButtonConfig } from '../../../api/types/common-defs/index.ts'
 
 // Derived from the generated schema types so the effect unions can never drift
-// from the editor's options (hoverEffectsList / buttonConfig in common-defs)
-export type HoverEffect = SchemaHoverEffects[number]
+// from the editor's options (hoverEffectsList / hoverConfigTopics / buttonConfig in common-defs).
+// Topics bring "invert", which only makes sense on a chip that toggles a filter.
+export type HoverEffect = SchemaHoverEffects[number] | SchemaTopicsEffects[number]
 
 export type HoverLike = { effects?: HoverEffect[], color?: string }
 
@@ -43,11 +44,8 @@ const transformTransition = hoverTransition('transform')
 // explicit effects: [] means no effect, absent means inherit
 export const resolveHoverConfig = (config?: HoverLike, portalDefaults?: HoverLike, relevantEffects?: HoverEffect[]): ResolvedHoverConfig => {
   let effects = config?.effects ?? portalDefaults?.effects ?? ['darken' as HoverEffect]
-  if (relevantEffects) {
-    const filtered = effects.filter(e => relevantEffects.includes(e))
-    if (filtered.length || !effects.length) effects = filtered
-    else effects = ['darken'] // the filter removed everything the user picked
-  }
+  // an effect the current context can't render is dropped, never substituted
+  if (relevantEffects) effects = effects.filter(e => relevantEffects.includes(e))
   return { effects, color: config?.color ?? portalDefaults?.color ?? 'primary' }
 }
 
@@ -82,6 +80,11 @@ export const hoverRootStyle = (resolved: ResolvedHoverConfig, isHovering: boolea
       style.color = onThemeColor(resolved.color)
     }
     transitions.push(hoverTransition('background-color'), hoverTransition('color'))
+  }
+  // The component swaps the filled/outlined variant itself, only the tempo is declared here:
+  // .v-chip carries no native transition, so the flip would be abrupt.
+  if (resolved.effects.includes('invert')) {
+    transitions.push(hoverTransition('background-color'), hoverTransition('color'), hoverTransition('border-color'))
   }
   if (transitions.length) style.transition = [...(opts?.small ? [chipNativeTransition] : cardNativeTransitions), ...transitions].join(', ')
   return Object.keys(style).length ? style : undefined

--- a/tests/features/portal-rendering/hover-config.unit.spec.ts
+++ b/tests/features/portal-rendering/hover-config.unit.spec.ts
@@ -21,11 +21,11 @@ test.describe('hover config resolution', () => {
     assert.deepEqual(resolveHoverConfig({ effects: [] }, { effects: ['elevate'] }).effects, [])
   })
 
-  test('relevant effects filter keeps subset, falls back to darken when nothing relevant remains', () => {
+  test('relevant effects filter drops what the context cannot render, without substituting darken', () => {
     const subset = resolveHoverConfig({ effects: ['background', 'elevate'] }, undefined, ['darken', 'background'])
     assert.deepEqual(subset.effects, ['background'])
-    const fallback = resolveHoverConfig({ effects: ['elevate'] }, undefined, ['darken', 'background'])
-    assert.deepEqual(fallback.effects, ['darken'])
+    const dropped = resolveHoverConfig({ effects: ['elevate'] }, undefined, ['darken', 'background'])
+    assert.deepEqual(dropped.effects, [])
     const emptied = resolveHoverConfig({ effects: [] }, undefined, ['darken', 'background'])
     assert.deepEqual(emptied.effects, [])
   })
@@ -78,6 +78,13 @@ test.describe('hover props helpers', () => {
     const hovering = hoverRootStyle(resolved, true)
     assert.equal(hovering?.borderColor, 'rgb(var(--v-theme-accent))')
     assert.equal(hoverRootStyle(resolved, true, { hasBorder: true })?.border, undefined)
+  })
+
+  test('invert declares the transitions a chip has no native tempo for', () => {
+    const transition = hoverRootStyle(resolveHoverConfig({ effects: ['invert'] }), true, { small: true })?.transition ?? ''
+    assert.match(transition, /background-color \.15s/)
+    assert.match(transition, /border-color \.15s/)
+    assert.match(transition, /color \.15s/)
   })
 
   test('inline background option writes background and on-color inline', () => {


### PR DESCRIPTION
The hover effects of the topics list now depend on how the chips are used. A topics block is either a link to the catalog or a toggle filter, and a filter chip already encodes its state through its fill — so offering it a "background color" effect was offering something the renderer had to throw away.

- an outlined chip no longer turns its border white when the background effect fills it: the inline text color was dragging the border along through `currentColor`, the border now keeps its resting color and only the border effect repaints it
- the effects list is built per mode through a `layout.switch` with static `items` — json-layout only derives the options from the `oneOf` when the layout provides none, so both modes share one field and one stored value while offering different options
- link mode keeps darken / elevate / grow / background / border; filter mode swaps background for a new `invert` effect and gains the border effect, whose hover color is now offered there too
- `invert`: hovering an inactive filter fills it, hovering an active one empties it, previewing what the click is about to do — fill, text and icon follow the effective variant so Vuetify computes the contrast, and the transition is declared explicitly since `.v-chip` carries none natively in Vuetify 4
- the darken fallback is gone: an effect the current mode cannot render is dropped, never substituted, so picking one no longer forces a darken on top
- the topics hover config is wrapped in a card, like the box element

**Why:** on the reported configuration (redirect + outlined + background) the border was washed to white, and in filter mode the background option did nothing while silently forcing the darken effect back on.

**Heads-up:**

- existing configs render identically unless a filter-mode topics block resolves to `border` (it gains a colored border where it used to fall back to darken) or to `background` alone (it loses the forced darken). Checked against opendata.edf.fr: both its topics blocks inherit the portal defaults, which resolve to darken, so neither page changes
- every value stays valid in the `oneOf` whatever the mode, so switching a block from redirect to filter never invalidates a stored config — the irrelevant effect is just ignored
- `resolveHoverConfig`'s fallback removal only reaches the topics list; it is the only caller passing a relevant-effects filter
