### PR TITLE
fix(portal): trigger login on client side navigation to a protected route

### DIFF
--- a/portal/app/middleware/auth-required.ts
+++ b/portal/app/middleware/auth-required.ts
@@ -1,7 +1,14 @@
-export default defineNuxtRouteMiddleware((to, from) => {
+export default defineNuxtRouteMiddleware((to) => {
   const session = useSession()
-  if (!session.user.value) {
-    // the error page will trigger a login when receiving this statusCode
-    return abortNavigation({ message: 'Authentification nécessaire', statusCode: 401 })
+  if (session.user.value) return
+
+  // on a client side navigation the router swallows the error below (it only renders the error
+  // page on the server and during hydration), so the login has to be triggered from here
+  if (import.meta.client && !useNuxtApp().isHydrating) {
+    session.login(window.location.origin + useRouter().resolve(to).href)
+    return abortNavigation()
   }
+
+  // the error page will trigger a login when receiving this statusCode
+  return abortNavigation({ message: 'Authentification nécessaire', statusCode: 401 })
 })


### PR DESCRIPTION
The "Rendez-vous dans votre espace personnel" link of the reuse invitation did nothing for anonymous visitors. `abortNavigation` only renders the error page on the server and during hydration (`nuxt/dist/pages/runtime/plugins/router.js:177`); once hydrated, the router plugin hands the non-`fatal` error back to vue-router, which cancels the navigation in silence — no error page, no login, no URL change. `NuxtLink` never awaits `router.push`, so the click was a no-op.

- `auth-required` now detects the client side navigation case and calls `session.login()` itself, passing the requested route as the redirect target
- that redirect target matters: the navigation is cancelled, so `topLocation.href` still points at the page the visitor came from — without it, logging in would land them back on the dataset page instead of the reuse form
- the server / hydration path is unchanged: 401 → error page → `session.login()`

**Why:** reported on a staging dataset page, where the reuse invitation is the only client side link to a protected route reachable while anonymous (the personal menu calls `session.login()` directly).

**Heads-up:**

- the middleware guards the whole `/me/*` subtree, so the behavior change applies to every protected route, not just the reuse invitation
- `useNuxtApp().isHydrating` gates the new branch; a future Nuxt release rendering the error page on client side navigations too would make it redundant rather than wrong
- no automated regression test: the only anonymous-reachable client side link to `/me/*` lives on a dataset page, which needs a real data-fair dataset and no test in the repo creates one. Verified manually on a throwaway dev portal — anonymous client navigation now redirects to the login with the requested route as `redirect`, anonymous direct load still 401s into the login, authenticated navigation is unaffected
