### PR TITLE
fix(portal): wrap dataset data section in a bordered sheet

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
     profiles:
       - dev
       - test
-    image: ghcr.io/data-fair/data-fair:feat-publication-sites-permissions-mode
+    image: ghcr.io/data-fair/data-fair:master
     restart: on-failure:10
     network_mode: host
     depends_on:

--- a/portal/app/pages/datasets/[ref]/index.vue
+++ b/portal/app/pages/datasets/[ref]/index.vue
@@ -96,63 +96,63 @@
           }"
         />
 
-        <v-tabs
-          v-model="dataTab"
+        <v-sheet
+          border
+          rounded
           class="mb-4"
         >
-          <v-tab value="table">
-            {{ t('sections.table') }}
-          </v-tab>
-          <v-tab
-            v-if="dataset.bbox?.length"
-            value="map"
-          >
-            {{ t('sections.map') }}
-          </v-tab>
-          <v-tab value="schema">
-            {{ t('sections.schema') }}
-          </v-tab>
-        </v-tabs>
+          <v-tabs v-model="dataTab">
+            <v-tab value="table">
+              {{ t('sections.table') }}
+            </v-tab>
+            <v-tab
+              v-if="dataset.bbox?.length"
+              value="map"
+            >
+              {{ t('sections.map') }}
+            </v-tab>
+            <v-tab value="schema">
+              {{ t('sections.schema') }}
+            </v-tab>
+          </v-tabs>
 
-        <v-tabs-window
-          v-model="dataTab"
-          class="mb-8"
-        >
-          <v-tabs-window-item value="table">
-            <d-frame-wrapper
-              :iframe-title="`${t('sections.table')} - ${dataset.title}`"
-              :src="`/data-fair/embed/dataset/${dataset.id}/table`"
-              scrolling="no"
-              resize="no"
-              aspect-ratio
-              sync-params
-              emit-iframe-messages
-              @iframe-message="(iframeMessage: CustomEvent) => onIframeMessage(iframeMessage.detail)"
-            />
-          </v-tabs-window-item>
+          <v-tabs-window v-model="dataTab">
+            <v-tabs-window-item value="table">
+              <d-frame-wrapper
+                :iframe-title="`${t('sections.table')} - ${dataset.title}`"
+                :src="`/data-fair/embed/dataset/${dataset.id}/table`"
+                scrolling="no"
+                resize="no"
+                aspect-ratio
+                sync-params
+                emit-iframe-messages
+                @iframe-message="(iframeMessage: CustomEvent) => onIframeMessage(iframeMessage.detail)"
+              />
+            </v-tabs-window-item>
 
-          <v-tabs-window-item
-            v-if="dataset.bbox?.length"
-            value="map"
-          >
-            <d-frame-wrapper
-              :iframe-title="`${t('sections.map')} - ${dataset.title}`"
-              :src="`/data-fair/embed/dataset/${dataset.id}/map`"
-              scrolling="no"
-              resize="no"
-              aspect-ratio
-            />
-          </v-tabs-window-item>
+            <v-tabs-window-item
+              v-if="dataset.bbox?.length"
+              value="map"
+            >
+              <d-frame-wrapper
+                :iframe-title="`${t('sections.map')} - ${dataset.title}`"
+                :src="`/data-fair/embed/dataset/${dataset.id}/map`"
+                scrolling="no"
+                resize="no"
+                aspect-ratio
+              />
+            </v-tabs-window-item>
 
-          <v-tabs-window-item value="schema">
-            <d-frame-wrapper
-              :iframe-title="`${t('sections.schema')} - ${dataset.title}`"
-              :src="`/data-fair/embed/dataset/${dataset.id}/fields`"
-              resize="no"
-              aspect-ratio
-            />
-          </v-tabs-window-item>
-        </v-tabs-window>
+            <v-tabs-window-item value="schema">
+              <d-frame-wrapper
+                :iframe-title="`${t('sections.schema')} - ${dataset.title}`"
+                :src="`/data-fair/embed/dataset/${dataset.id}/fields`"
+                resize="no"
+                aspect-ratio
+              />
+            </v-tabs-window-item>
+          </v-tabs-window>
+        </v-sheet>
       </template>
 
       <!-- Applications section -->


### PR DESCRIPTION
The Data section of the dataset page now sits in a bordered, rounded `v-sheet` instead of floating tabs over the page background.

- tabs (Table / Map / Schema) and their content are wrapped in one `v-sheet border rounded`
- bottom margin aligned on the other sections (`mb-4` instead of the previous `mb-8`)

**Why:** the section looked flat with `portalConfig.datasets.page.showData` enabled.

**Regression risks:**
- spacing under the section narrows from `mb-8` to `mb-4` (intentional, consistent with the other sections)
- the sheet adds a surface background behind the embed iframes — worth a quick check on dark/custom themes

**Riding along:**
- `docker-compose.yml`: dev/test image switched to `ghcr.io/data-fair/data-fair:master`
