### PR TITLE
fix(ui): keep the page elements editor context in sync with the pages list

### DIFF
--- a/ui/src/components/page-edit/page-edit-elements.vue
+++ b/ui/src/components/page-edit/page-edit-elements.vue
@@ -73,15 +73,14 @@ const { addItemMessage, pages } = defineProps<{ addItemMessage: string, pages: a
 const session = useSessionAuthenticated()
 const pageRef = { type: 'page' as const, _id: inject('page-id') as string }
 
-const vjsfOptions: VjsfOptions = {
+// computed, otherwise the context would freeze the pages list as it was on setup,
+// before the pages fetch of the parent resolves, and no link could target a page
+const vjsfOptions = computed<VjsfOptions>(() => ({
   titleDepth: 4,
   density: 'compact',
   updateOn: 'blur',
   initialValidation: 'always',
-  // @ts-ignore
-  messages: {
-    addItem: addItemMessage
-  },
+  messages: { addItem: addItemMessage } as VjsfOptions['messages'],
   pluginsOptions: {
     markdown: {
       cspNonce: $cspNonce,
@@ -92,7 +91,7 @@ const vjsfOptions: VjsfOptions = {
     close: '$tableGroupExpand'
   },
   context: { pages, adminMode: session.user.value.adminMode }
-}
+}))
 </script>
 
 <style lang="css">


### PR DESCRIPTION
The VJSF options of the page elements editor were built once on setup, so their `context` froze the pages list as it was at that moment. When the editor mounted before the parent's pages fetch resolved, the "Page" selector of every link stayed empty ("Aucune donnée disponible") and no link could target a page — navigation button and menu elements included.

- `vjsfOptions` becomes a `computed`, so the context follows the `pages` prop instead of a setup-time snapshot
- the `@ts-ignore` on `messages` becomes a typed cast, since the comment no longer applies from inside the getter

**Why:** on a page draft, configuring a link towards a page was failing at random — the editor mounting before `GET /api/pages` resolved was enough to lose the whole list for the rest of the session.

**Heads-up:**
- the options object now changes identity on every recompute; `useVjsf` handles that (it compares options before rebuilding), but the page editor is sensitive to state-tree rebuilds — that is the part worth reviewing.
- no automated test: the failure depends on a race between the component mounting and the fetch. Reproduced by delaying `GET /api/pages` by 6 s, and verified before/after — empty selector, then the full list and a link persisted with a `PATCH` 200.
