### PR TITLE
fix(portal): degrade blocks instead of blocking the render when data-fair is down

### DIFF
--- a/dev/worktree.sh
+++ b/dev/worktree.sh
@@ -101,6 +101,11 @@ echo "Create .env file"
 echo "npm ci"
 npm ci
 
+# no postinstall hook applies them, so an unpatched worktree fails the tests that
+# cover our vuetify patches (cf the Dockerfile, which patches the same way)
+echo "npx patch-package"
+npx patch-package --error-on-fail
+
 echo "npm run build-types"
 npm run build-types
 

--- a/portal/app/components/content-unavailable.vue
+++ b/portal/app/components/content-unavailable.vue
@@ -1,0 +1,30 @@
+<template>
+  <v-alert
+    :title="t('title')"
+    :text="t('text')"
+    type="warning"
+    variant="tonal"
+  />
+</template>
+
+<script setup lang="ts">
+const { t } = useI18n()
+
+// A page rendered without part of its content must not be indexed as is: a 503 tells the
+// crawler to come back later. An error status already set by page-error is more specific,
+// it wins. This runs at render time, when the fetches of the page have settled.
+const event = useRequestEvent()
+if (event && event.node.res.statusCode < 400) {
+  setResponseStatus(event, 503)
+  useResponseHeader('Retry-After').value = '60'
+}
+</script>
+
+<i18n lang="yaml">
+  en:
+    title: Content temporarily unavailable
+    text: This content could not be loaded, please try again in a few moments.
+  fr:
+    title: Contenu temporairement indisponible
+    text: Ce contenu n'a pas pu être chargé, veuillez réessayer dans quelques instants.
+</i18n>

--- a/portal/app/components/page-element/applications/page-element-application.vue
+++ b/portal/app/components/page-element/applications/page-element-application.vue
@@ -1,6 +1,10 @@
 <template>
+  <content-unavailable
+    v-if="unavailable"
+    :class="element.mb !== 0 && `mb-${element.mb ?? 4}`"
+  />
   <div
-    v-if="element.application?.slug"
+    v-else-if="element.application?.slug"
     :class="element.mb !== 0 && `mb-${element.mb ?? 4}`"
   >
     <application-actions
@@ -111,6 +115,7 @@ const pillarboxStyle = computed(() => {
 const applicationFetcher = preview ? useFetch<Application> : useLocalFetch<Application>
 const applicationFetch = applicationFetcher(() => element.application?.id ? '/data-fair/api/v1/applications/' + element.application.id : '')
 const application = computed(() => applicationFetch.data.value)
+const unavailable = computed(() => isContentUnavailable(applicationFetch.error?.value))
 </script>
 
 <i18n lang="yaml">

--- a/portal/app/components/page-element/applications/page-element-applications-catalog.vue
+++ b/portal/app/components/page-element/applications/page-element-applications-catalog.vue
@@ -1,5 +1,7 @@
 <template>
+  <content-unavailable v-if="unavailable" />
   <catalog-layout
+    v-else
     catalog-type="applications"
     :element="element"
     :context="context"
@@ -52,7 +54,7 @@ const { t } = useI18n()
 
 const {
   displayedItems, itemsCount, loading, currentPage, totalPages,
-  sort, order, goToPage, loadMore
+  sort, order, goToPage, loadMore, unavailable
 } = useCatalog<Application, ApplicationFilters>(element, {
   endpoint: '/data-fair/api/v1/applications',
   defaultSortFallback: 'createdAt:-1',

--- a/portal/app/components/page-element/applications/page-element-applications-list.vue
+++ b/portal/app/components/page-element/applications/page-element-applications-list.vue
@@ -1,5 +1,12 @@
 <template>
-  <v-row :class="['d-flex align-stretch', element.mb !== 0 && `mb-${element.mb ?? 4}`]">
+  <content-unavailable
+    v-if="unavailable"
+    :class="element.mb !== 0 && `mb-${element.mb ?? 4}`"
+  />
+  <v-row
+    v-else
+    :class="['d-flex align-stretch', element.mb !== 0 && `mb-${element.mb ?? 4}`]"
+  >
     <v-col
       v-for="application in displayedApplications"
       :key="application.id"
@@ -24,6 +31,7 @@ const { element } = defineProps<{ element: ApplicationsListElement }>()
 const { portal, preview, portalConfig } = usePortalStore()
 
 let displayedApplications: Application[] | ComputedRef<Application[]>
+let unavailable: ComputedRef<boolean>
 
 if (!preview) {
   const ids = element.applications?.map(app => app.id) || []
@@ -36,6 +44,7 @@ if (!preview) {
   }))
 
   const applicationsFetch = useLocalFetch<ApplicationFetch>('/data-fair/api/v1/applications', { query: applicationsQuery })
+  unavailable = computed(() => isContentUnavailable(applicationsFetch.error.value))
   displayedApplications = computed(() => {
     const results = applicationsFetch.data.value?.results || []
     if (element.mode === 'custom') return [...results].sort((a, b) => ids.indexOf(a.id) - ids.indexOf(b.id)) // order by element.applications
@@ -43,6 +52,7 @@ if (!preview) {
   })
 } else {
   const session = useSessionAuthenticated()
+  unavailable = computed(() => false)
 
   // Mock data for preview
   displayedApplications = computed(() => {

--- a/portal/app/components/page-element/basic/page-element-metrics.vue
+++ b/portal/app/components/page-element/basic/page-element-metrics.vue
@@ -1,5 +1,12 @@
 <template>
-  <v-row class="justify-center align-center">
+  <content-unavailable
+    v-if="unavailable"
+    :class="element.mb !== 0 && `mb-${element.mb ?? 4}`"
+  />
+  <v-row
+    v-else
+    class="justify-center align-center"
+  >
     <v-col
       v-for="key in element.metrics"
       :key="key"
@@ -36,6 +43,7 @@ const { preview, portal } = usePortalStore()
 const { t, locale } = useI18n()
 
 let metrics: { datasets: number, records: number, applications: number } | ComputedRef<{ datasets: number, records: number, applications: number }>
+let unavailable: ComputedRef<boolean>
 if (!preview) {
   // TODO: stats for private user ? (owner and visibility)
   const datasetsMetricsFetch = useLocalFetch<{ count: number, sums: { count: number } }>('/data-fair/api/v1/catalog/datasets', {
@@ -51,12 +59,14 @@ if (!preview) {
     }
   })
 
+  unavailable = computed(() => isContentUnavailable(datasetsMetricsFetch.error.value) || isContentUnavailable(applicationsMetricsFetch.error.value))
   metrics = computed(() => ({
     datasets: datasetsMetricsFetch.data.value?.count || 0,
     records: datasetsMetricsFetch.data.value?.sums.count || 0,
     applications: applicationsMetricsFetch.data.value?.count || 0,
   }))
 } else {
+  unavailable = computed(() => false)
   metrics = {
     datasets: 100,
     records: 10_000_000,

--- a/portal/app/components/page-element/basic/page-element-topics.vue
+++ b/portal/app/components/page-element/basic/page-element-topics.vue
@@ -1,6 +1,10 @@
 <template>
+  <content-unavailable
+    v-if="unavailable"
+    :class="element.mb !== 0 && `mb-${element.mb ?? 4}`"
+  />
   <div
-    v-if="topicsItems.length"
+    v-else-if="topicsItems.length"
     :class="element.mb !== 0 && `mb-${element.mb ?? 4}`"
   >
     <topics-list
@@ -46,6 +50,7 @@ type TopicItem = {
 }
 
 let topicsItems: TopicItem[] | ComputedRef<TopicItem[]>
+let unavailable: ComputedRef<boolean>
 
 if (!preview) {
   const fetches = modes.value.map(m => useLocalFetch<{
@@ -62,6 +67,7 @@ if (!preview) {
       publicationSites: 'data-fair-portals:' + portal.value._id,
     }
   }))
+  unavailable = computed(() => fetches.some(fetch => isContentUnavailable(fetch.error.value)))
   topicsItems = computed(() => {
     // Merge topics from every source, summing counts for topics that appear in several catalogs.
     const merged = new Map<string, TopicItem>()
@@ -75,6 +81,7 @@ if (!preview) {
     return Array.from(merged.values())
   })
 } else {
+  unavailable = computed(() => false)
   topicsItems = [
     { id: 'topic-1', title: 'Topic 1', count: 10, icon: { svgPath: mdiHome } },
     { id: 'topic-2', title: 'Topic 2', count: 5, color: '#A0F' },

--- a/portal/app/components/page-element/datasets/page-element-dataset-card.vue
+++ b/portal/app/components/page-element/datasets/page-element-dataset-card.vue
@@ -1,6 +1,10 @@
 <template>
+  <content-unavailable
+    v-if="unavailable"
+    :class="element.mb !== 0 && `mb-${element.mb ?? 4}`"
+  />
   <dataset-card
-    v-if="datasetFetch.data?.value"
+    v-else-if="datasetFetch.data?.value"
     :class="element.mb !== 0 && `mb-${element.mb ?? 4}`"
     :dataset="datasetFetch.data?.value"
     :card-config="(!element.usePortalConfig && element.cardConfig) ? element.cardConfig : portalConfig.datasets.card"
@@ -17,6 +21,8 @@ const { portalConfig, preview } = usePortalStore()
 
 const fetch = preview ? useFetch<Dataset> : useLocalFetch<Dataset>
 const datasetFetch = fetch(() => element.dataset?.id ? '/data-fair/api/v1/datasets/' + element.dataset?.id : '', { immediate: false })
+
+const unavailable = computed(() => isContentUnavailable(datasetFetch.error?.value))
 
 watch(() => element.dataset?.id, (id) => {
   if (id) datasetFetch.refresh()

--- a/portal/app/components/page-element/datasets/page-element-datasets-catalog.vue
+++ b/portal/app/components/page-element/datasets/page-element-datasets-catalog.vue
@@ -1,5 +1,7 @@
 <template>
+  <content-unavailable v-if="unavailable" />
   <catalog-layout
+    v-else
     catalog-type="datasets"
     :element="element"
     :context="context"
@@ -69,7 +71,7 @@ const { t } = useI18n()
 
 const {
   displayedItems, itemsCount, loading, currentPage, totalPages,
-  sort, order, goToPage, loadMore
+  sort, order, goToPage, loadMore, unavailable
 } = useCatalog<DatasetResult, DatasetFilters>(element, {
   endpoint: '/data-fair/api/v1/datasets',
   defaultSortFallback: 'createdAt:-1',

--- a/portal/app/components/page-element/datasets/page-element-datasets-list.vue
+++ b/portal/app/components/page-element/datasets/page-element-datasets-list.vue
@@ -1,5 +1,12 @@
 <template>
-  <v-row :class="['d-flex align-stretch', element.mb !== 0 && `mb-${element.mb ?? 4}`]">
+  <content-unavailable
+    v-if="unavailable"
+    :class="element.mb !== 0 && `mb-${element.mb ?? 4}`"
+  />
+  <v-row
+    v-else
+    :class="['d-flex align-stretch', element.mb !== 0 && `mb-${element.mb ?? 4}`]"
+  >
     <v-col
       v-for="dataset in displayedDatasets"
       :key="dataset.id"
@@ -25,6 +32,7 @@ const { element } = defineProps<{ element: DatasetsListElement }>()
 const { portal, portalConfig, preview } = usePortalStore()
 
 let displayedDatasets: ComputedRef<DatasetFetch['results']>
+let unavailable: ComputedRef<boolean>
 
 if (!preview) {
   const ids = element.datasets?.map(d => d.id) || []
@@ -38,6 +46,7 @@ if (!preview) {
   }))
 
   const datasetsFetch = useLocalFetch<DatasetFetch>('/data-fair/api/v1/datasets', { query: datasetsQuery })
+  unavailable = computed(() => isContentUnavailable(datasetsFetch.error.value))
   displayedDatasets = computed(() => {
     const results = datasetsFetch.data.value?.results || []
     if (element.mode === 'custom') return [...results].sort((a, b) => ids.indexOf(a.id) - ids.indexOf(b.id)) // order by element.datasets
@@ -45,6 +54,7 @@ if (!preview) {
   })
 } else {
   const session = useSessionAuthenticated()
+  unavailable = computed(() => false)
 
   // Mock data for preview
   displayedDatasets = computed(() => {

--- a/portal/app/composables/use-catalog.ts
+++ b/portal/app/composables/use-catalog.ts
@@ -2,8 +2,6 @@ import type { WritableComputedRef } from 'vue'
 
 type FetchResult<T> = { count: number; results: T[] }
 
-type CatalogError = { statusCode?: number; message?: string }
-
 export type FilterRef =
   | WritableComputedRef<string, string>
   | WritableComputedRef<string[], string[]>
@@ -17,7 +15,8 @@ export interface CatalogReturn<T, F> {
   totalPages: ComputedRef<number>
   sort: Ref<string | undefined>
   order: Ref<'-1' | '1' | undefined>
-  error: Ref<CatalogError | undefined>
+  /** the items could not be fetched and the block should say so, cf utils/content-unavailable */
+  unavailable: ComputedRef<boolean>
   goToPage: (page: number) => Promise<void>
   loadMore: (paginationPosition?: string) => Promise<void>
   filters: F
@@ -136,7 +135,7 @@ export function useCatalog<T, F extends Record<string, FilterRef>> (
     totalPages,
     sort,
     order,
-    error: itemsFetch.error,
+    unavailable: computed(() => isContentUnavailable(itemsFetch.error.value)),
     goToPage,
     loadMore,
     filters

--- a/portal/app/composables/use-catalog.ts
+++ b/portal/app/composables/use-catalog.ts
@@ -2,6 +2,8 @@ import type { WritableComputedRef } from 'vue'
 
 type FetchResult<T> = { count: number; results: T[] }
 
+type CatalogError = { statusCode?: number; message?: string }
+
 export type FilterRef =
   | WritableComputedRef<string, string>
   | WritableComputedRef<string[], string[]>
@@ -15,6 +17,7 @@ export interface CatalogReturn<T, F> {
   totalPages: ComputedRef<number>
   sort: Ref<string | undefined>
   order: Ref<'-1' | '1' | undefined>
+  error: Ref<CatalogError | undefined>
   /** the items could not be fetched and the block should say so, cf utils/content-unavailable */
   unavailable: ComputedRef<boolean>
   goToPage: (page: number) => Promise<void>
@@ -135,6 +138,7 @@ export function useCatalog<T, F extends Record<string, FilterRef>> (
     totalPages,
     sort,
     order,
+    error: itemsFetch.error,
     unavailable: computed(() => isContentUnavailable(itemsFetch.error.value)),
     goToPage,
     loadMore,

--- a/portal/app/pages/applications/[ref]/index.vue
+++ b/portal/app/pages/applications/[ref]/index.vue
@@ -3,7 +3,7 @@
     <!-- Error state -->
     <page-error
       v-if="applicationFetch.error.value"
-      :status-code="applicationFetch.error.value.statusCode || 500"
+      :status-code="applicationFetch.error.value.statusCode || 503"
       :title="errorTitle"
       :link="applicationsCatalogExists ? {
         type: 'standard',

--- a/portal/app/pages/datasets/[ref]/index.vue
+++ b/portal/app/pages/datasets/[ref]/index.vue
@@ -3,7 +3,7 @@
     <!-- Error state -->
     <page-error
       v-if="datasetFetch.error.value"
-      :status-code="datasetFetch.error.value.statusCode || 500"
+      :status-code="datasetFetch.error.value.statusCode || 503"
       :title="errorTitle"
       :link="datasetsCatalogExists ? {
         type: 'standard',

--- a/portal/app/plugins/01-local-fetch.ts
+++ b/portal/app/plugins/01-local-fetch.ts
@@ -4,18 +4,28 @@
 import { getRequestHeader, getRequestURL } from 'h3'
 import type { Dispatcher } from 'undici'
 
+// data-fair is the least stable dependency of a portal, its ssr calls get their own
+// dispatcher: a short inactivity timeout (undici defaults to 300s) so a slow or down
+// data-fair degrades the blocks that need it instead of blocking the whole page render,
+// and a separate connection pool so it cannot starve the calls to our own services
+const dataFairTimeout = 5000
+
 export default defineNuxtPlugin(async () => {
   let _ssrDispatcher: Dispatcher
+  let _ssrDataFairDispatcher: Dispatcher
 
   if (import.meta.server) {
     const { Agent, interceptors } = await import('undici')
-    _ssrDispatcher = new Agent({
+    const createDispatcher = (options?: { headersTimeout: number, bodyTimeout: number }) => new Agent({
       connections: 8,
-      allowH2: true
+      allowH2: true,
+      ...options
     }).compose(interceptors.dns({
       // our load balancers ips should not change
       maxTTL: Infinity
     }))
+    _ssrDispatcher = createDispatcher()
+    _ssrDataFairDispatcher = createDispatcher({ headersTimeout: dataFairTimeout, bodyTimeout: dataFairTimeout })
   }
 
   const localFetch = $fetch.create({
@@ -31,7 +41,7 @@ export default defineNuxtPlugin(async () => {
         if (secretIgnoreRateLimiting) options.headers.set('x-ignore-rate-limiting', secretIgnoreRateLimiting)
         options.baseURL = origin
         options.retry = 0
-        options.dispatcher = _ssrDispatcher
+        options.dispatcher = url.startsWith('/data-fair/') ? _ssrDataFairDispatcher : _ssrDispatcher
       }
     }
   })

--- a/portal/app/utils/content-unavailable.ts
+++ b/portal/app/utils/content-unavailable.ts
@@ -1,0 +1,9 @@
+// data-fair is the least stable dependency of a portal and its ssr calls are capped by a
+// short timeout (cf plugins/01-local-fetch.ts). A block that could not get its content must
+// say so instead of rendering an empty list, and the page is then served as a 503.
+// A timeout or an unreachable service produces an error without status code.
+export function isContentUnavailable (error: unknown) {
+  if (!error) return false
+  const statusCode = (error as { statusCode?: number }).statusCode
+  return !statusCode || statusCode >= 500
+}

--- a/tests/features/portal-rendering/content-unavailable.e2e.spec.ts
+++ b/tests/features/portal-rendering/content-unavailable.e2e.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '../../fixtures/portal.ts'
+import { axiosAuth, clean } from '../../support/axios.ts'
+
+const user1 = await axiosAuth('test_admin@test.com')
+
+test.describe('data-fair content unavailable', () => {
+  test.beforeEach(clean)
+
+  test('a catalog warns instead of showing an empty result when data-fair cannot be reached', async ({ page, goToPortal }) => {
+    const portal = (await user1.post('/api/portals', {
+      config: { title: 'Data Fair Down Portal', menu: { children: [] } }
+    })).data
+    await user1.post('/api/pages', {
+      type: 'datasets',
+      config: {
+        title: 'Catalogue',
+        elements: [{ uuid: 'dc1', type: 'datasets-catalog', columns: 2, filters: { items: ['search'] } }]
+      },
+      portals: [portal._id],
+      owner: portal.owner
+    })
+
+    await goToPortal(portal._id, '/datasets')
+    const search = page.getByRole('textbox', { name: 'Rechercher', exact: true })
+    await expect(search).toBeVisible({ timeout: 10_000 })
+
+    // data-fair is down: the search cannot be answered anymore
+    await page.route('**/data-fair/api/**', route => route.abort())
+
+    // a search submitted before hydration does nothing, retry with a new term each time
+    // (the search field is gone once the warning replaced the catalog)
+    const warning = page.getByText('Contenu temporairement indisponible')
+    let attempt = 0
+    await expect.poll(async () => {
+      if (await warning.isVisible()) return true
+      await search.fill(`recherche-${attempt++}`)
+      await search.press('Enter')
+      return warning.isVisible()
+    }, { timeout: 20_000 }).toBe(true)
+  })
+})

--- a/tests/features/portal-rendering/content-unavailable.unit.spec.ts
+++ b/tests/features/portal-rendering/content-unavailable.unit.spec.ts
@@ -1,0 +1,27 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { isContentUnavailable } from '../../../portal/app/utils/content-unavailable.ts'
+
+test.describe('content unavailable detection', () => {
+  test('no error means the content is available', () => {
+    assert.equal(isContentUnavailable(null), false)
+    assert.equal(isContentUnavailable(undefined), false)
+  })
+
+  test('a network error or timeout has no status code and means unavailable', () => {
+    assert.equal(isContentUnavailable({}), true)
+    assert.equal(isContentUnavailable({ statusCode: undefined }), true)
+  })
+
+  test('server errors mean unavailable', () => {
+    assert.equal(isContentUnavailable({ statusCode: 500 }), true)
+    assert.equal(isContentUnavailable({ statusCode: 502 }), true)
+    assert.equal(isContentUnavailable({ statusCode: 503 }), true)
+  })
+
+  test('client errors are legitimate answers, not an outage', () => {
+    assert.equal(isContentUnavailable({ statusCode: 401 }), false)
+    assert.equal(isContentUnavailable({ statusCode: 403 }), false)
+    assert.equal(isContentUnavailable({ statusCode: 404 }), false)
+  })
+})

--- a/ui/src/composables/nuxt-composables.ts
+++ b/ui/src/composables/nuxt-composables.ts
@@ -46,3 +46,7 @@ export function useBackOfficeUrl (): any {
 export function useEditResourceLink (_kind: any, _resource: any): any {
   throw new Error('useEditResourceLink should only be called from portal, not portals-manager')
 }
+
+export function useResponseHeader (_name: string): Ref<string | undefined> {
+  throw new Error('useResponseHeader should only be called from portal, not portals-manager')
+}

--- a/ui/src/composables/use-catalog.ts
+++ b/ui/src/composables/use-catalog.ts
@@ -14,7 +14,7 @@ export function useCatalog<T, F extends Record<string, FilterRef>> (
     totalPages: computed(() => 1),
     sort: computed({ get: () => undefined as string | undefined, set: () => {} }),
     order: computed({ get: () => undefined as '-1' | '1' | undefined, set: () => {} }),
-    error: ref(undefined),
+    unavailable: computed(() => false),
     goToPage: async () => { },
     loadMore: async () => { },
     filters: {} as F

--- a/ui/src/composables/use-catalog.ts
+++ b/ui/src/composables/use-catalog.ts
@@ -14,6 +14,7 @@ export function useCatalog<T, F extends Record<string, FilterRef>> (
     totalPages: computed(() => 1),
     sort: computed({ get: () => undefined as string | undefined, set: () => {} }),
     order: computed({ get: () => undefined as '-1' | '1' | undefined, set: () => {} }),
+    error: ref(undefined),
     unavailable: computed(() => false),
     goToPage: async () => { },
     loadMore: async () => { },

--- a/ui/src/utils/content-unavailable.ts
+++ b/ui/src/utils/content-unavailable.ts
@@ -1,0 +1,5 @@
+import * as contentUnavailable from '../../../portal/app/utils/content-unavailable'
+
+// Local const re-declaration (not `export ... from`) so unplugin-auto-import also emits the
+// template-scope declaration, cf utils/hover.ts
+export const isContentUnavailable = contentUnavailable.isContentUnavailable


### PR DESCRIPTION
When data-fair answers slowly or not at all, a portal goes dark: its ssr calls toward data-fair had no timeout — undici defaults to 300s — so one hanging call held a whole page render hostage, including pages that need no dataset. This restores the graceful degradation the v1 portals have, without giving up ssr rendering of the datasets, which is the whole point of indexing them.

- data-fair ssr calls go through their own undici dispatcher, capped at 5s of inactivity, with a connection pool separate from the calls to our own services
- every block that takes its content from data-fair (metrics, topics, datasets and applications lists and catalogs, dataset card, application) renders a warning instead of looking empty — a catalog used to announce "0 jeu de données" and the metrics to show zeros
- such a page is served as a 503 with `Retry-After: 60`, so a crawler comes back later rather than indexing a portal emptied of its datasets; the dataset and application pages get the same treatment, their 500 fallback becomes a 503
- `useCatalog` exposes an `unavailable` boolean next to its existing fetch `error`
- `chore`: `dev/worktree.sh` runs `npx patch-package`, which nothing did on install — a fresh worktree ran on an unpatched vuetify and failed the tab slider e2e test, with no relation to the branch under work

**Why:** measured on opendata.edf.fr while data-fair was struggling — the portal served nothing, where a v1 portal (data.ademe.fr) still served its pages. The difference is not ssr, both render server side, but the absence of any timeout and a single connection pool shared by every service call.

**Heads-up:**
- the 5s cutoff itself is not covered by a test: undici's timers are too coarse to trip on a local data-fair that answers in ~30ms. What is verified end to end is everything after the failure — degraded block, 503, `Retry-After` — by hand against a data-fair returning 500, and by an e2e test for the client side navigation.
- answering 503 because *blocks* failed is deliberate, and worth challenging: it trades a degraded page for a crawler that comes back. A status already set by `page-error` (404, 403) still wins.
- the news, events and reuses catalogs share `useCatalog` but keep their current behavior, silently empty: they query the portal API, not data-fair. One line each if we want them covered.
- the two `ui` files are type plumbing for the shared components' auto-imports, no behavior change in the page editor.

